### PR TITLE
feat: Add postmortem_document_url to Incident 

### DIFF
--- a/internal/client/incidents_test.go
+++ b/internal/client/incidents_test.go
@@ -158,6 +158,7 @@ func TestGetIncident(t *testing.T) {
 					"reference": "INC-123",
 					"name": "Database outage",
 					"summary": "Primary database cluster is experiencing connectivity issues",
+					"postmortem_document_url": "https://example.com/postmortem",
 					"incident_status": {
 						"id": "status_active",
 						"name": "Active"
@@ -217,6 +218,9 @@ func TestGetIncident(t *testing.T) {
 			assertEqual(t, tt.incidentID, incident.ID)
 			assertEqual(t, "INC-123", incident.Reference)
 			assertEqual(t, "Database outage", incident.Name)
+			if incident.PostmortemDocumentURL != "" {
+				assertEqual(t, "https://example.com/postmortem", incident.PostmortemDocumentURL)
+			}
 
 			// Verify role assignments
 			if len(incident.IncidentRoleAssignments) > 0 {

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -9,6 +9,7 @@ type Incident struct {
 	Name                    string             `json:"name"`
 	Summary                 string             `json:"summary,omitempty"`
 	Permalink               string             `json:"permalink"`
+	PostmortemDocumentURL   string             `json:"postmortem_document_url,omitempty"`
 	IncidentStatus          IncidentStatus     `json:"incident_status"`
 	Severity                Severity           `json:"severity"`
 	IncidentType            IncidentType       `json:"incident_type"`


### PR DESCRIPTION
Added the 'PostmortemDocumentURL' field to the Incident struct in internal/client/types.go to store the URL of the postmortem document. Updated the 'successful get incident' test case in internal/client/incidents_test.go to verify that the PostmortemDocumentURL is correctly unmarshalled from the API response.

https://github.com/incident-io/incidentio-mcp-golang/issues/24