### PR TITLE
feat(update_incident): Add custom_field_entries support

### DIFF
--- a/internal/handlers/incidents.go
+++ b/internal/handlers/incidents.go
@@ -530,6 +530,27 @@ func (t *UpdateIncidentTool) InputSchema() map[string]interface{} {
 				"type":        "string",
 				"description": "Update the severity ID",
 			},
+			"custom_field_entries": map[string]interface{}{
+				"type":        "array",
+				"description": "Custom field entries to update. Each entry needs a custom_field_id and an array of value objects. For select fields, each value object should have a 'value_option_id' key with the option ID. For text fields, use 'value_text'. For numeric, use 'value_numeric'. For link, use 'value_link'.",
+				"items": map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"custom_field_id": map[string]interface{}{
+							"type":        "string",
+							"description": "The ID of the custom field to set",
+						},
+						"values": map[string]interface{}{
+							"type":        "array",
+							"description": "Array of value objects for this field",
+							"items": map[string]interface{}{
+								"type": "object",
+							},
+						},
+					},
+					"required": []interface{}{"custom_field_id", "values"},
+				},
+			},
 		},
 		"required":             []interface{}{"incident_id"},
 		"additionalProperties": false,
@@ -565,6 +586,29 @@ func (t *UpdateIncidentTool) Execute(args map[string]interface{}) (string, error
 	if severityID, ok := args["severity_id"].(string); ok {
 		req.SeverityID = severityID
 		hasUpdate = true
+	}
+
+	if entries, ok := args["custom_field_entries"].([]interface{}); ok && len(entries) > 0 {
+		var customFieldEntries []client.CustomFieldEntryRequest
+		for _, entry := range entries {
+			entryMap, ok := entry.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			fieldID, _ := entryMap["custom_field_id"].(string)
+			if fieldID == "" {
+				continue
+			}
+			values, _ := entryMap["values"].([]interface{})
+			customFieldEntries = append(customFieldEntries, client.CustomFieldEntryRequest{
+				CustomFieldID: fieldID,
+				Values:        values,
+			})
+		}
+		if len(customFieldEntries) > 0 {
+			req.CustomFieldEntries = customFieldEntries
+			hasUpdate = true
+		}
 	}
 
 	if !hasUpdate {

--- a/internal/handlers/incidents_test.go
+++ b/internal/handlers/incidents_test.go
@@ -41,6 +41,132 @@ func TestCreateIncidentTool_Execute(t *testing.T) {
 	// but we can test the parameter validation and schema
 }
 
+func TestUpdateIncidentTool_Schema(t *testing.T) {
+	tool := &UpdateIncidentTool{}
+
+	// Test Name
+	if tool.Name() != "update_incident" {
+		t.Errorf("Expected name 'update_incident', got %s", tool.Name())
+	}
+
+	// Test InputSchema has custom_field_entries
+	schema := tool.InputSchema()
+	properties := schema["properties"].(map[string]interface{})
+
+	if _, ok := properties["custom_field_entries"]; !ok {
+		t.Error("Schema should have 'custom_field_entries' property")
+	}
+
+	// Verify custom_field_entries is an array type
+	cfe := properties["custom_field_entries"].(map[string]interface{})
+	if cfe["type"] != "array" {
+		t.Errorf("custom_field_entries should be type 'array', got %v", cfe["type"])
+	}
+
+	// Verify items schema has required fields
+	items := cfe["items"].(map[string]interface{})
+	itemProps := items["properties"].(map[string]interface{})
+	if _, ok := itemProps["custom_field_id"]; !ok {
+		t.Error("custom_field_entries items should have 'custom_field_id' property")
+	}
+	if _, ok := itemProps["values"]; !ok {
+		t.Error("custom_field_entries items should have 'values' property")
+	}
+}
+
+func TestUpdateIncidentTool_Execute(t *testing.T) {
+	tool := &UpdateIncidentTool{}
+
+	// Test missing required incident_id parameter
+	t.Run("missing incident_id", func(t *testing.T) {
+		args := map[string]interface{}{
+			"name": "Test",
+		}
+		_, err := tool.Execute(args)
+		if err == nil {
+			t.Error("Expected error for missing incident_id")
+		}
+	})
+
+	// Test no update fields provided
+	t.Run("no update fields", func(t *testing.T) {
+		args := map[string]interface{}{
+			"incident_id": "some-id",
+		}
+		_, err := tool.Execute(args)
+		if err == nil {
+			t.Error("Expected error when no update fields are provided")
+		}
+		if err.Error() != "at least one field to update must be provided" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	// Test custom_field_entries is recognized as a valid update field
+	// (will panic at API call since no client, but should get past validation)
+	t.Run("custom_field_entries counts as update", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				// Expected: nil pointer dereference because apiClient is nil
+				// This means we got past the "at least one field" validation
+			}
+		}()
+
+		args := map[string]interface{}{
+			"incident_id": "some-id",
+			"custom_field_entries": []interface{}{
+				map[string]interface{}{
+					"custom_field_id": "field-123",
+					"values": []interface{}{
+						map[string]interface{}{
+							"value_catalog_entry_id": "option-456",
+						},
+					},
+				},
+			},
+		}
+		_, err := tool.Execute(args)
+		if err != nil && err.Error() == "at least one field to update must be provided" {
+			t.Error("custom_field_entries should count as a valid update field")
+		}
+	})
+
+	// Test custom_field_entries with empty entries is not counted
+	t.Run("empty custom_field_entries not counted", func(t *testing.T) {
+		args := map[string]interface{}{
+			"incident_id":          "some-id",
+			"custom_field_entries": []interface{}{},
+		}
+		_, err := tool.Execute(args)
+		if err == nil {
+			t.Error("Expected error when custom_field_entries is empty")
+		}
+		if err.Error() != "at least one field to update must be provided" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+
+	// Test custom_field_entries with invalid entries are skipped
+	t.Run("invalid entries skipped", func(t *testing.T) {
+		args := map[string]interface{}{
+			"incident_id": "some-id",
+			"custom_field_entries": []interface{}{
+				map[string]interface{}{
+					// Missing custom_field_id
+					"values": []interface{}{},
+				},
+			},
+		}
+		_, err := tool.Execute(args)
+		if err == nil {
+			t.Error("Expected error when all entries are invalid")
+		}
+		if err.Error() != "at least one field to update must be provided" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	})
+}
+
 func TestCreateIncidentTool_Schema(t *testing.T) {
 	tool := &CreateIncidentTool{}
 


### PR DESCRIPTION
## Summary
- Exposes `custom_field_entries` in the `update_incident` MCP tool's `InputSchema()` and `Execute()` method
- The client layer already supported custom field entries — this change bridges the gap in the handler layer
- Adds unit tests for schema validation, parameter parsing, and edge cases (empty/invalid entries)

## Motivation
The `update_incident` tool only supported updating `name`, `summary`, `incident_status_id`, and `severity_id`. This made it impossible to set custom field values (e.g., alert quality classifications) on incidents through the MCP tool, requiring manual UI updates.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (5 new tests added)
- [x] Verified end-to-end by setting a multi_select custom field on a live incident

🤖 Generated with [Claude Code](https://claude.com/claude-code)