### PR TITLE
Fix stdio MCP server hang on Ctrl-C

### DIFF
--- a/cmd/mcp-server/main.go
+++ b/cmd/mcp-server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -49,6 +50,10 @@ func main() {
 
 	srv := server.NewWithConfig(cfg)
 	if err := srv.Start(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			log.Println("Server stopped")
+			return
+		}
 		log.Printf("Server error: %v", err)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,25 +69,51 @@ func (s *Server) Start(ctx context.Context) error {
 }
 
 func (s *Server) startStdio(ctx context.Context) error {
-	encoder := json.NewEncoder(os.Stdout)
-	decoder := json.NewDecoder(os.Stdin)
+	return s.startStdioWithIO(ctx, os.Stdin, os.Stdout)
+}
+
+func (s *Server) startStdioWithIO(ctx context.Context, in io.Reader, out io.Writer) error {
+	encoder := json.NewEncoder(out)
+	decoder := json.NewDecoder(in)
+
+	type decodeResult struct {
+		msg mcp.Message
+		err error
+	}
+
+	decodeCh := make(chan decodeResult)
+	go func() {
+		for {
+			var msg mcp.Message
+			err := decoder.Decode(&msg)
+
+			select {
+			case decodeCh <- decodeResult{msg: msg, err: err}:
+			case <-ctx.Done():
+				return
+			}
+
+			if err == io.EOF {
+				return
+			}
+		}
+	}()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		default:
-			var msg mcp.Message
-			if err := decoder.Decode(&msg); err != nil {
-				if err == io.EOF {
+		case decoded := <-decodeCh:
+			if decoded.err != nil {
+				if decoded.err == io.EOF {
 					return nil
 				}
 				continue
 			}
 
-			response, err := s.handleMessage(&msg)
+			response, err := s.handleMessage(&decoded.msg)
 			if err != nil {
-				response = s.createErrorResponse(msg.ID, err)
+				response = s.createErrorResponse(decoded.msg.ID, err)
 			}
 
 			if response != nil {

--- a/internal/server/server_stdio_test.go
+++ b/internal/server/server_stdio_test.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStartStdioReturnsOnContextCancelWhileBlockedOnStdin(t *testing.T) {
+	originalStdin := os.Stdin
+	originalStdout := os.Stdout
+
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdin pipe: %v", err)
+	}
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stdout pipe: %v", err)
+	}
+
+	os.Stdin = stdinReader
+	os.Stdout = stdoutWriter
+
+	t.Cleanup(func() {
+		os.Stdin = originalStdin
+		os.Stdout = originalStdout
+		_ = stdinReader.Close()
+		_ = stdinWriter.Close()
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := New()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.startStdio(ctx)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	select {
+	case runErr := <-errCh:
+		if !errors.Is(runErr, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", runErr)
+		}
+	case <-time.After(200 * time.Millisecond):
+		_ = stdinWriter.Close()
+		select {
+		case <-errCh:
+		case <-time.After(200 * time.Millisecond):
+		}
+		t.Fatal("startStdio did not return after context cancellation")
+	}
+}
+
+type blockingReader struct {
+	started chan struct{}
+	once    sync.Once
+}
+
+func (r *blockingReader) Read(_ []byte) (int, error) {
+	r.once.Do(func() {
+		close(r.started)
+	})
+	select {}
+}
+
+func TestStartStdioWithIOReturnsOnContextCancelWhenReaderBlocks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reader := &blockingReader{started: make(chan struct{})}
+
+	srv := New()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.startStdioWithIO(ctx, reader, io.Discard)
+	}()
+
+	select {
+	case <-reader.started:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("decoder did not start reading")
+	}
+
+	cancel()
+
+	select {
+	case runErr := <-errCh:
+		if !errors.Is(runErr, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", runErr)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("startStdioWithIO did not return after context cancellation")
+	}
+}


### PR DESCRIPTION
This PR fixes a shutdown bug in the stdio transport where `Ctrl-C` could log graceful shutdown but leave the MCP server running indefinitely. The process now exits promptly when cancellation is requested.

The issue was that shutdown depended on a blocking stdin decode loop. If stdin was idle, the server could not observe context cancellation, so it never completed shutdown after receiving `SIGINT`/`SIGTERM`.

This change decouples decoding from the shutdown path so cancellation is always observable, even when reads are blocked. It also treats `context.Canceled` as a normal stop in `main`, and adds regression tests that reproduce blocked-reader scenarios and assert clean termination.

Tested with `go test ./...`.
