### PR TITLE
feat: add auto-paginating text search for list_alerts & list_incidents

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cp .env.example .env
 
 ### Incident Management
 
-- `list_incidents` - List incidents with optional filters
+- `list_incidents` - List incidents with optional filters and auto-paginating name search
 - `get_incident` - Get details of a specific incident
 - `create_incident` - Create a new incident
 - `update_incident` - Update an existing incident
@@ -102,7 +102,7 @@ cp .env.example .env
 
 ### Alert Management
 
-- `list_alerts` - List alerts with optional filters
+- `list_alerts` - List alerts with optional filters, title search, and alert source filtering
 - `get_alert` - Get details of a specific alert
 - `list_incident_alerts` - List connections between incidents and alerts
 - `create_alert_event` - Create an alert event

--- a/internal/client/alerts.go
+++ b/internal/client/alerts.go
@@ -13,6 +13,7 @@ type ListAlertsOptions struct {
 	After              string
 	Status             []string
 	DeduplicationKey   string // Filter by deduplication key
+	AlertSourceID      string // Filter by alert source ID
 	CreatedAtGte       string // Filter alerts created on or after this date
 	CreatedAtLte       string // Filter alerts created on or before this date
 	CreatedAtDateRange string // Filter alerts created within date range (format: "2024-12-02~2024-12-08")
@@ -67,6 +68,10 @@ func (c *Client) ListAlerts(opts *ListAlertsOptions) (*ListAlertsResponse, error
 
 		if opts.DeduplicationKey != "" {
 			params.Set("deduplication_key[is]", opts.DeduplicationKey)
+		}
+
+		if opts.AlertSourceID != "" {
+			params.Set("alert_source_id[is]", opts.AlertSourceID)
 		}
 
 		if opts.CreatedAtGte != "" {

--- a/internal/handlers/alerts.go
+++ b/internal/handlers/alerts.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/incident-io/incidentio-mcp-golang/internal/client"
 )
@@ -22,7 +23,11 @@ func (t *ListAlertsTool) Name() string {
 
 func (t *ListAlertsTool) Description() string {
 	return "List alerts from incident.io with optional filters. Returns paginated results.\n\n" +
-		"🚨 CRITICAL PAGINATION REQUIREMENT:\n" +
+		"TITLE SEARCH:\n" +
+		"Use 'title' for case-insensitive substring search on alert titles. " +
+		"Auto-paginates all pages and returns up to 50 matches — no manual pagination needed. " +
+		"Combine with alert_source_id or date filters to narrow server-side results.\n\n" +
+		"🚨 CRITICAL PAGINATION REQUIREMENT (when not using title search):\n" +
 		"1. Start with page_size=25 (API default)\n" +
 		"2. Check pagination_meta.after in response\n" +
 		"3. If 'after' exists, you MUST call again with after parameter\n" +
@@ -32,6 +37,7 @@ func (t *ListAlertsTool) Description() string {
 		"📊 Always check if there are more pages before concluding your analysis!\n\n" +
 		"FILTERING:\n" +
 		"- Use status to filter by alert status (firing, resolved, etc.)\n" +
+		"- Use alert_source_id to filter by alert source (server-side)\n" +
 		"- Use created_at_gte/created_at_lte to filter by creation date\n" +
 		"- Use created_at_date_range for date range filtering (format: '2024-12-02~2024-12-08')\n" +
 		"- Use deduplication_key to filter by specific deduplication key\n" +
@@ -44,8 +50,9 @@ func (t *ListAlertsTool) Description() string {
 		"- Past month: created_at_gte=\"2025-01-15\" (calculate 30 days ago)\n" +
 		"- Before date: created_at_lte=\"2025-01-15\"\n" +
 		"- Date format: '2025-08-29' (date only, no time)\n\n" +
-		"PAGINATION EXAMPLE:\n" +
-		"User: 'alerts with Sentry in name for past week'\n" +
+		"PAGINATION EXAMPLES:\n" +
+		"Title search: list_alerts({\"title\": \"Sentry\", \"created_at_gte\": \"2025-01-08\"})\n" +
+		"Manual pagination:\n" +
 		"1. list_alerts({\"created_at_gte\": \"2025-01-08\", \"page_size\": 25})\n" +
 		"2. If pagination_meta.after exists, call again with after parameter\n" +
 		"3. Continue until pagination_meta.after is empty\n" +
@@ -57,6 +64,10 @@ func (t *ListAlertsTool) InputSchema() map[string]interface{} {
 	return map[string]interface{}{
 		"type": "object",
 		"properties": map[string]interface{}{
+			"title": map[string]interface{}{
+				"type":        "string",
+				"description": "Case-insensitive substring search on alert title. Auto-paginates all pages and returns up to 50 matches. When set, page_size and after are ignored.",
+			},
 			"page_size": map[string]interface{}{
 				"type":        "integer",
 				"description": "Number of results per page (1-50). Default is 25 (API default). Use smaller values if you need fewer results.",
@@ -77,6 +88,10 @@ func (t *ListAlertsTool) InputSchema() map[string]interface{} {
 				"type":        "string",
 				"description": "Filter by deduplication key. Exact match required.",
 			},
+			"alert_source_id": map[string]interface{}{
+				"type":        "string",
+				"description": "Filter by alert source ID (exact match, server-side).",
+			},
 			"created_at_gte": map[string]interface{}{
 				"type":        "string",
 				"description": "Filter alerts created on or after this date. Format: '2025-01-15' (date only, no time)",
@@ -94,20 +109,68 @@ func (t *ListAlertsTool) InputSchema() map[string]interface{} {
 }
 
 func (t *ListAlertsTool) Execute(args map[string]interface{}) (string, error) {
-	opts := &client.ListAlertsOptions{
-		PageSize: GetIntArg(args, "page_size", 25), // Use API default page size
-		After:    GetStringArg(args, "after"),
-	}
+	titleFilter := strings.ToLower(GetStringArg(args, "title"))
 
+	// Server-side filters
+	opts := &client.ListAlertsOptions{}
 	opts.Status = GetStringArrayArg(args, "status")
-
-	if deduplicationKey := GetStringArg(args, "deduplication_key"); deduplicationKey != "" {
-		opts.DeduplicationKey = deduplicationKey
+	if dk := GetStringArg(args, "deduplication_key"); dk != "" {
+		opts.DeduplicationKey = dk
 	}
-
+	if asi := GetStringArg(args, "alert_source_id"); asi != "" {
+		opts.AlertSourceID = asi
+	}
 	opts.CreatedAtGte = GetStringArg(args, "created_at_gte")
 	opts.CreatedAtLte = GetStringArg(args, "created_at_lte")
 	opts.CreatedAtDateRange = GetStringArg(args, "created_at_date_range")
+
+	// Auto-paginating title search
+	if titleFilter != "" {
+		opts.PageSize = 50 // max API page size
+		var matched []client.Alert
+		pagesScanned := 0
+
+		for pagesScanned < maxSearchPages {
+			resp, err := t.apiClient.ListAlerts(opts)
+			if err != nil {
+				return "", err
+			}
+			pagesScanned++
+
+			for i := range resp.Alerts {
+				if strings.Contains(strings.ToLower(resp.Alerts[i].Title), titleFilter) {
+					matched = append(matched, resp.Alerts[i])
+					if len(matched) >= maxSearchResults {
+						break
+					}
+				}
+			}
+
+			if len(matched) >= maxSearchResults || resp.PaginationMeta.After == "" {
+				break
+			}
+			opts.After = resp.PaginationMeta.After
+		}
+
+		response := map[string]interface{}{
+			"alerts":        matched,
+			"count":         len(matched),
+			"title_filter":  titleFilter,
+			"pages_scanned": pagesScanned,
+		}
+		if len(matched) >= maxSearchResults {
+			response["truncated"] = true
+			response["note"] = fmt.Sprintf("Result limit (%d) reached. Narrow with date/status filters.", maxSearchResults)
+		} else if pagesScanned >= maxSearchPages {
+			response["scan_truncated"] = true
+			response["note"] = fmt.Sprintf("Page limit (%d) reached. Use date or alert_source_id filters to narrow results.", maxSearchPages)
+		}
+		return FormatJSONResponse(response)
+	}
+
+	// Standard single-page mode
+	opts.PageSize = GetIntArg(args, "page_size", 25)
+	opts.After = GetStringArg(args, "after")
 
 	resp, err := t.apiClient.ListAlerts(opts)
 	if err != nil {

--- a/internal/handlers/helpers.go
+++ b/internal/handlers/helpers.go
@@ -5,6 +5,11 @@ import (
 	"fmt"
 )
 
+const (
+	maxSearchResults = 50
+	maxSearchPages   = 50
+)
+
 // FormatJSONResponse is a simple helper to eliminate JSON marshaling duplication
 func FormatJSONResponse(response interface{}) (string, error) {
 	result, err := json.MarshalIndent(response, "", "  ")

--- a/internal/handlers/incidents.go
+++ b/internal/handlers/incidents.go
@@ -25,7 +25,8 @@ func (t *ListIncidentsTool) Name() string {
 func (t *ListIncidentsTool) Description() string {
 	return "List incidents with filtering. Returns compact summaries by default to avoid large responses.\n\n" +
 		"KEY FEATURES:\n" +
-		"- search: Filter by name (e.g., search='speechify' finds all Speechify incidents)\n" +
+		"- search: Filter by name (e.g., search='speechify' finds all Speechify incidents). " +
+		"Auto-paginates all pages and returns up to 50 matches — no manual pagination needed.\n" +
 		"- summary: true (default) returns compact summaries, false returns full details\n" +
 		"- page_size: Default 25, increase only if needed\n" +
 		"- incident_type_id: Filter by incident type IDs (use list_incident_types to get IDs)\n\n" +
@@ -37,7 +38,7 @@ func (t *ListIncidentsTool) Description() string {
 		"Recent incidents: list_incidents({\"created_at_gte\": \"2025-01-28\"})\n" +
 		"Full details: list_incidents({\"search\": \"speechify\", \"summary\": false})\n" +
 		"Filter by type: list_incidents({\"incident_type_id\": [\"01ABC123\"]})\n\n" +
-		"PAGINATION:\n" +
+		"PAGINATION (when not using search):\n" +
 		"If has_more_results=true, call again with 'after' cursor from pagination_meta.\n\n" +
 		"INCIDENT REFERENCE RESOLUTION:\n" +
 		"For INC-1691, use get_incident({\"incident_id\": \"1691\"}) for full details.\n\n" +
@@ -50,7 +51,7 @@ func (t *ListIncidentsTool) InputSchema() map[string]interface{} {
 		"properties": map[string]interface{}{
 			"search": map[string]interface{}{
 				"type":        "string",
-				"description": "Filter incidents by name (case-insensitive substring match). Example: 'speechify' returns all incidents with 'speechify' in the name.",
+				"description": "Filter incidents by name (case-insensitive substring match). Auto-paginates all pages and returns up to 50 matches. Example: 'speechify' returns all incidents with 'speechify' in the name.",
 			},
 			"summary": map[string]interface{}{
 				"type":        "boolean",
@@ -59,14 +60,14 @@ func (t *ListIncidentsTool) InputSchema() map[string]interface{} {
 			},
 			"page_size": map[string]interface{}{
 				"type":        "integer",
-				"description": "Number of results per page. Default is 25. Use 50-100 only if you need more results per page.",
+				"description": "Number of results per page. Default is 25. Use 50-100 only if you need more results per page. Ignored when search is set.",
 				"default":     25,
 				"minimum":     1,
 				"maximum":     100,
 			},
 			"after": map[string]interface{}{
 				"type":        "string",
-				"description": "Pagination cursor from previous response. Get this from pagination_meta.after in the previous response.",
+				"description": "Pagination cursor from previous response. Get this from pagination_meta.after in the previous response. Ignored when search is set.",
 			},
 			"status": map[string]interface{}{
 				"type":        "array",
@@ -121,19 +122,33 @@ func (t *ListIncidentsTool) InputSchema() map[string]interface{} {
 
 // IncidentSummary is a lightweight representation for list responses
 type IncidentSummary struct {
-	Reference  string `json:"reference"`
-	Name       string `json:"name"`
-	Status     string `json:"status"`
-	Severity   string `json:"severity"`
-	CreatedAt  string `json:"created_at"`
-	UpdatedAt  string `json:"updated_at"`
-	Permalink  string `json:"permalink"`
+	Reference string `json:"reference"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Severity  string `json:"severity"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+	Permalink string `json:"permalink"`
+}
+
+func toSummaries(incidents []client.Incident) []IncidentSummary {
+	summaries := make([]IncidentSummary, 0, len(incidents))
+	for _, inc := range incidents {
+		summaries = append(summaries, IncidentSummary{
+			Reference: inc.Reference,
+			Name:      inc.Name,
+			Status:    inc.IncidentStatus.Name,
+			Severity:  inc.Severity.Name,
+			CreatedAt: inc.CreatedAt.Format(time.RFC3339),
+			UpdatedAt: inc.UpdatedAt.Format(time.RFC3339),
+			Permalink: inc.Permalink,
+		})
+	}
+	return summaries
 }
 
 func (t *ListIncidentsTool) Execute(args map[string]interface{}) (string, error) {
-	opts := &client.ListIncidentsOptions{
-		PageSize: 25, // Default to 25 for reasonable response sizes
-	}
+	opts := &client.ListIncidentsOptions{}
 
 	// Parse search filter
 	searchFilter := ""
@@ -147,14 +162,7 @@ func (t *ListIncidentsTool) Execute(args map[string]interface{}) (string, error)
 		summaryMode = summary
 	}
 
-	if pageSize, ok := args["page_size"].(float64); ok {
-		opts.PageSize = int(pageSize)
-	}
-
-	if after, ok := args["after"].(string); ok && after != "" {
-		opts.After = after
-	}
-
+	// Server-side filters
 	if statuses, ok := args["status"].([]interface{}); ok {
 		for _, s := range statuses {
 			if str, ok := s.(string); ok {
@@ -213,53 +221,85 @@ func (t *ListIncidentsTool) Execute(args map[string]interface{}) (string, error)
 		}
 	}
 
+	// Auto-paginating search mode
+	if searchFilter != "" {
+		opts.PageSize = 250 // max API page size for incidents
+		var matched []client.Incident
+		pagesScanned := 0
+
+		for pagesScanned < maxSearchPages {
+			resp, err := t.apiClient.ListIncidents(opts)
+			if err != nil {
+				return "", err
+			}
+			pagesScanned++
+
+			for i := range resp.Incidents {
+				if strings.Contains(strings.ToLower(resp.Incidents[i].Name), searchFilter) {
+					matched = append(matched, resp.Incidents[i])
+					if len(matched) >= maxSearchResults {
+						break
+					}
+				}
+			}
+
+			if len(matched) >= maxSearchResults || resp.PaginationMeta.After == "" {
+				break
+			}
+			opts.After = resp.PaginationMeta.After
+		}
+
+		var incidentsData interface{}
+		if summaryMode {
+			incidentsData = toSummaries(matched)
+		} else {
+			incidentsData = matched
+		}
+
+		response := map[string]interface{}{
+			"incidents":     incidentsData,
+			"count":         len(matched),
+			"search_filter": searchFilter,
+			"pages_scanned": pagesScanned,
+		}
+		if len(matched) >= maxSearchResults {
+			response["truncated"] = true
+			response["note"] = fmt.Sprintf("Result limit (%d) reached. Narrow with date/status filters.", maxSearchResults)
+		} else if pagesScanned >= maxSearchPages {
+			response["scan_truncated"] = true
+			response["note"] = fmt.Sprintf("Page limit (%d) reached. Use date or status filters to narrow results.", maxSearchPages)
+		}
+		return FormatJSONResponse(response)
+	}
+
+	// Standard single-page mode
+	if pageSize, ok := args["page_size"].(float64); ok {
+		opts.PageSize = int(pageSize)
+	} else {
+		opts.PageSize = 25 // Default to 25 for reasonable response sizes
+	}
+
+	if after, ok := args["after"].(string); ok && after != "" {
+		opts.After = after
+	}
+
 	resp, err := t.apiClient.ListIncidents(opts)
 	if err != nil {
 		return "", err
 	}
 
-	// Apply search filter if provided
-	filteredIncidents := resp.Incidents
-	if searchFilter != "" {
-		filteredIncidents = nil
-		for _, inc := range resp.Incidents {
-			if strings.Contains(strings.ToLower(inc.Name), searchFilter) {
-				filteredIncidents = append(filteredIncidents, inc)
-			}
-		}
-	}
-
-	// Build response based on summary mode
 	var incidentsData interface{}
 	if summaryMode {
-		summaries := make([]IncidentSummary, 0, len(filteredIncidents))
-		for _, inc := range filteredIncidents {
-			summaries = append(summaries, IncidentSummary{
-				Reference:  inc.Reference,
-				Name:       inc.Name,
-				Status:     inc.IncidentStatus.Name,
-				Severity:   inc.Severity.Name,
-				CreatedAt:  inc.CreatedAt.Format(time.RFC3339),
-				UpdatedAt:  inc.UpdatedAt.Format(time.RFC3339),
-				Permalink:  inc.Permalink,
-			})
-		}
-		incidentsData = summaries
+		incidentsData = toSummaries(resp.Incidents)
 	} else {
-		incidentsData = filteredIncidents
+		incidentsData = resp.Incidents
 	}
 
 	// Create response with prominent pagination info
 	response := map[string]interface{}{
 		"incidents":       incidentsData,
 		"pagination_meta": resp.PaginationMeta,
-		"count":           len(filteredIncidents),
-	}
-
-	// Add note about search filtering if applied
-	if searchFilter != "" {
-		response["search_applied"] = searchFilter
-		response["search_note"] = fmt.Sprintf("Filtered %d incidents from %d total on this page", len(filteredIncidents), len(resp.Incidents))
+		"count":           len(resp.Incidents),
 	}
 
 	// Add prominent pagination status

--- a/internal/handlers/refactored_tools_test.go
+++ b/internal/handlers/refactored_tools_test.go
@@ -208,7 +208,7 @@ func TestListAlertsTool_Schema(t *testing.T) {
 	}
 
 	properties := schema["properties"].(map[string]interface{})
-	expectedProps := []string{"page_size", "after", "status", "deduplication_key", "created_at_gte", "created_at_lte", "created_at_date_range"}
+	expectedProps := []string{"title", "page_size", "after", "status", "deduplication_key", "alert_source_id", "created_at_gte", "created_at_lte", "created_at_date_range"}
 	for _, prop := range expectedProps {
 		if _, ok := properties[prop]; !ok {
 			t.Errorf("Schema should have '%s' property", prop)

--- a/internal/handlers/search_test.go
+++ b/internal/handlers/search_test.go
@@ -1,0 +1,424 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/incident-io/incidentio-mcp-golang/internal/client"
+)
+
+func newTestClient(t *testing.T, srv *httptest.Server) *client.Client {
+	t.Helper()
+	t.Setenv("INCIDENT_IO_API_KEY", "test-key")
+	c, err := client.NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.SetBaseURL(srv.URL)
+	return c
+}
+
+func unmarshalResult(t *testing.T, result string) map[string]interface{} {
+	t.Helper()
+	var resp map[string]interface{}
+	if err := json.Unmarshal([]byte(result), &resp); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	return resp
+}
+
+func fakeAlert(title string) client.Alert {
+	return client.Alert{
+		ID:        "alert-" + title,
+		Title:     title,
+		Status:    "firing",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+}
+
+func fakeIncident(name string) client.Incident {
+	return client.Incident{
+		ID:             "inc-" + name,
+		Reference:      "INC-1",
+		Name:           name,
+		Permalink:      "https://app.incident.io/incidents/inc-" + name,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+		IncidentStatus: client.IncidentStatus{Name: "active"},
+		Severity:       client.Severity{Name: "minor"},
+	}
+}
+
+type alertPage struct {
+	alerts []client.Alert
+	after  string
+}
+
+type incidentPage struct {
+	incidents  []client.Incident
+	after      string
+	totalCount int
+}
+
+func pageIndex(after string, cursors []string) int {
+	if after != "" {
+		for i := range cursors {
+			if i > 0 && cursors[i-1] == after {
+				return i
+			}
+		}
+	}
+	return 0
+}
+
+func alertsHandler(pages []alertPage) http.HandlerFunc {
+	cursors := make([]string, len(pages))
+	for i, p := range pages {
+		cursors[i] = p.after
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		idx := pageIndex(r.URL.Query().Get("after"), cursors)
+		page := pages[idx]
+		resp := map[string]interface{}{
+			"alerts": page.alerts,
+			"pagination_meta": map[string]interface{}{
+				"after":              page.after,
+				"page_size":          len(page.alerts),
+				"total_record_count": 0,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func incidentsHandler(pages []incidentPage) http.HandlerFunc {
+	cursors := make([]string, len(pages))
+	for i, p := range pages {
+		cursors[i] = p.after
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		idx := pageIndex(r.URL.Query().Get("after"), cursors)
+		page := pages[idx]
+		resp := map[string]interface{}{
+			"incidents": page.incidents,
+			"pagination_meta": map[string]interface{}{
+				"after":              page.after,
+				"page_size":          len(page.incidents),
+				"total_record_count": page.totalCount,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func TestListAlerts_TitleSearch_AcrossPages(t *testing.T) {
+	pages := []alertPage{
+		{alerts: []client.Alert{fakeAlert("cpu spike"), fakeAlert("dw_devices_aggregation timeout")}, after: "cursor1"},
+		{alerts: []client.Alert{fakeAlert("memory OOM"), fakeAlert("disk full")}, after: "cursor2"},
+		{alerts: []client.Alert{fakeAlert("dw_devices_aggregation failure")}, after: ""},
+	}
+	srv := httptest.NewServer(alertsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListAlertsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"title": "dw_devices_aggregation",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	count := int(resp["count"].(float64))
+	if count != 2 {
+		t.Errorf("expected 2 matches, got %d", count)
+	}
+	pagesScanned := int(resp["pages_scanned"].(float64))
+	if pagesScanned != 3 {
+		t.Errorf("expected 3 pages scanned, got %d", pagesScanned)
+	}
+}
+
+func TestListAlerts_TitleSearch_CaseInsensitive(t *testing.T) {
+	pages := []alertPage{
+		{alerts: []client.Alert{fakeAlert("CPU Spike Alert"), fakeAlert("cpu spike warning")}, after: ""},
+	}
+	srv := httptest.NewServer(alertsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListAlertsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"title": "CPU SPIKE",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	if int(resp["count"].(float64)) != 2 {
+		t.Errorf("expected 2 case-insensitive matches, got %v", resp["count"])
+	}
+}
+
+func TestListAlerts_TitleSearch_StopsAtMaxResults(t *testing.T) {
+	var pages []alertPage
+	for i := 0; i < maxSearchPages; i++ {
+		var alerts []client.Alert
+		for j := 0; j < 10; j++ {
+			alerts = append(alerts, fakeAlert(fmt.Sprintf("match-%d-%d", i, j)))
+		}
+		cursor := ""
+		if i < maxSearchPages-1 {
+			cursor = fmt.Sprintf("cursor%d", i)
+		}
+		pages = append(pages, alertPage{alerts: alerts, after: cursor})
+	}
+	srv := httptest.NewServer(alertsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListAlertsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"title": "match",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	count := int(resp["count"].(float64))
+	if count != maxSearchResults {
+		t.Errorf("expected %d (maxSearchResults), got %d", maxSearchResults, count)
+	}
+	if resp["truncated"] != true {
+		t.Error("expected truncated=true")
+	}
+}
+
+func TestListAlerts_TitleSearch_ScanTruncated(t *testing.T) {
+	var pages []alertPage
+	for i := 0; i < maxSearchPages; i++ {
+		alerts := []client.Alert{fakeAlert(fmt.Sprintf("noise-%d", i))}
+		cursor := ""
+		if i < maxSearchPages-1 {
+			cursor = fmt.Sprintf("cursor%d", i)
+		}
+		pages = append(pages, alertPage{alerts: alerts, after: cursor})
+	}
+	srv := httptest.NewServer(alertsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListAlertsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"title": "nonexistent",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	if int(resp["count"].(float64)) != 0 {
+		t.Errorf("expected 0 matches, got %v", resp["count"])
+	}
+	if resp["scan_truncated"] != true {
+		t.Error("expected scan_truncated=true when page limit reached")
+	}
+	if resp["truncated"] != nil {
+		t.Error("truncated should not be set when result limit not reached")
+	}
+}
+
+func TestListAlerts_NoTitle_SinglePage(t *testing.T) {
+	pages := []alertPage{
+		{alerts: []client.Alert{fakeAlert("a1"), fakeAlert("a2")}, after: "next"},
+	}
+	srv := httptest.NewServer(alertsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListAlertsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"page_size": float64(25),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	if _, ok := resp["🚨 PAGINATION WARNING"]; !ok {
+		t.Error("expected pagination warning in standard mode with more pages")
+	}
+	fetchNext, ok := resp["📊 FETCH_NEXT_PAGE"].(map[string]interface{})
+	if !ok {
+		t.Error("expected FETCH_NEXT_PAGE in standard mode")
+	} else if fetchNext["after"] != "next" {
+		t.Errorf("expected FETCH_NEXT_PAGE.after='next', got %v", fetchNext["after"])
+	}
+	if _, ok := resp["title_filter"]; ok {
+		t.Error("title_filter should not be present in standard mode")
+	}
+}
+
+func TestListIncidents_Search_AcrossPages(t *testing.T) {
+	pages := []incidentPage{
+		{incidents: []client.Incident{fakeIncident("other-1"), fakeIncident("promtail failure")}, after: "c1", totalCount: 4},
+		{incidents: []client.Incident{fakeIncident("promtail restart"), fakeIncident("other-2")}, after: "", totalCount: 4},
+	}
+	srv := httptest.NewServer(incidentsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListIncidentsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"search": "promtail",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	count := int(resp["count"].(float64))
+	if count != 2 {
+		t.Errorf("expected 2 matches, got %d", count)
+	}
+	if int(resp["pages_scanned"].(float64)) != 2 {
+		t.Errorf("expected 2 pages scanned, got %v", resp["pages_scanned"])
+	}
+}
+
+func TestListIncidents_Search_StopsAtMaxResults(t *testing.T) {
+	var pages []incidentPage
+	for i := 0; i < maxSearchPages; i++ {
+		var incidents []client.Incident
+		for j := 0; j < 10; j++ {
+			incidents = append(incidents, fakeIncident(fmt.Sprintf("match-%d-%d", i, j)))
+		}
+		cursor := ""
+		if i < maxSearchPages-1 {
+			cursor = fmt.Sprintf("c%d", i)
+		}
+		pages = append(pages, incidentPage{incidents: incidents, after: cursor, totalCount: maxSearchPages * 10})
+	}
+	srv := httptest.NewServer(incidentsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListIncidentsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"search": "match",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	count := int(resp["count"].(float64))
+	if count != maxSearchResults {
+		t.Errorf("expected %d, got %d", maxSearchResults, count)
+	}
+	if resp["truncated"] != true {
+		t.Error("expected truncated=true")
+	}
+}
+
+func TestListIncidents_Search_SummaryMode(t *testing.T) {
+	pages := []incidentPage{
+		{incidents: []client.Incident{fakeIncident("target incident")}, after: "", totalCount: 1},
+	}
+	srv := httptest.NewServer(incidentsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListIncidentsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"search": "target",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	incidents := resp["incidents"].([]interface{})
+	if len(incidents) != 1 {
+		t.Fatalf("expected 1 incident, got %d", len(incidents))
+	}
+	inc := incidents[0].(map[string]interface{})
+	if _, ok := inc["reference"]; !ok {
+		t.Error("summary mode should include 'reference'")
+	}
+	if _, ok := inc["id"]; ok {
+		t.Error("summary mode should NOT include 'id'")
+	}
+}
+
+func TestListIncidents_Search_FullDetailMode(t *testing.T) {
+	pages := []incidentPage{
+		{incidents: []client.Incident{fakeIncident("target incident")}, after: "", totalCount: 1},
+	}
+	srv := httptest.NewServer(incidentsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListIncidentsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"search":  "target",
+		"summary": false,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	incidents := resp["incidents"].([]interface{})
+	if len(incidents) != 1 {
+		t.Fatalf("expected 1 incident, got %d", len(incidents))
+	}
+	inc := incidents[0].(map[string]interface{})
+	if _, ok := inc["id"]; !ok {
+		t.Error("full detail mode should include 'id'")
+	}
+	if _, ok := inc["reference"]; !ok {
+		t.Error("full detail mode should include 'reference'")
+	}
+}
+
+func TestListIncidents_NoSearch_SinglePage(t *testing.T) {
+	pages := []incidentPage{
+		{incidents: []client.Incident{fakeIncident("inc1")}, after: "next", totalCount: 100},
+	}
+	srv := httptest.NewServer(incidentsHandler(pages))
+	defer srv.Close()
+
+	tool := NewListIncidentsTool(newTestClient(t, srv))
+	result, err := tool.Execute(map[string]interface{}{
+		"page_size": float64(25),
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := unmarshalResult(t, result)
+
+	if resp["has_more_results"] != true {
+		t.Error("expected has_more_results=true in standard mode")
+	}
+	fetchNext, ok := resp["FETCH_NEXT_PAGE"].(map[string]interface{})
+	if !ok {
+		t.Error("expected FETCH_NEXT_PAGE in standard mode")
+	} else if fetchNext["after"] != "next" {
+		t.Errorf("expected FETCH_NEXT_PAGE.after='next', got %v", fetchNext["after"])
+	}
+	if _, ok := resp["search_filter"]; ok {
+		t.Error("search_filter should not be present in standard mode")
+	}
+}

--- a/internal/handlers/search_test.go
+++ b/internal/handlers/search_test.go
@@ -93,7 +93,7 @@ func alertsHandler(pages []alertPage) http.HandlerFunc {
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}
 }
 
@@ -114,7 +114,7 @@ func incidentsHandler(pages []incidentPage) http.HandlerFunc {
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(resp)
+		_ = json.NewEncoder(w).Encode(resp)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `list_alerts`: new `title` param for case-insensitive substring search across pages, new `alert_source_id` server-side filter
- `list_incidents`: `search` param now auto-paginates instead of requiring manual cursor management
- Both tools scan up to 50 pages and return up to 50 matches, with `pages_scanned`, `truncated`, and `scan_truncated` metadata

## Motivation

LLM agents struggle with multi-turn cursor-based pagination. Auto-paginating search makes these tools single-call for the most common use case (find by name). Server-side `alert_source_id` filter reduces scan cost for high-volume orgs.

## Test plan

- [x] `make test` passes (11 new tests in `search_test.go`)
- [x] Multi-page search, case insensitivity, result/scan truncation, standard single-page mode preserved
- [x] Summary vs full-detail mode for incidents
- [x] Verified `alert_source_id` filter against live incident.io API
- [x] `go vet` clean, `gofmt` clean
- [x] Backwards compatible — no changes to existing behavior when new params are omitted