### PR TITLE
Add incident_type filter to list_incidents

### DIFF
--- a/internal/client/incidents.go
+++ b/internal/client/incidents.go
@@ -17,6 +17,7 @@ type ListIncidentsOptions struct {
 	SeverityOneOf      []string // Filter by exact severity IDs (severity[one_of]=ID)
 	SeverityGte        string   // Filter by severity rank >= this ID (severity[gte]=ID)
 	SeverityLte        string   // Filter by severity rank <= this ID (severity[lte]=ID)
+	IncidentTypeOneOf  []string // Filter by incident type IDs (incident_type[one_of]=ID)
 	CreatedAtGte       string   // Greater than or equal to (format: "2024-12-02")
 	CreatedAtLte       string   // Less than or equal to (format: "2024-12-02")
 	CreatedAtDateRange string   // Date range (format: "2024-12-02~2024-12-08")
@@ -67,6 +68,9 @@ func (c *Client) ListIncidents(opts *ListIncidentsOptions) (*ListIncidentsRespon
 		}
 		if opts.SeverityLte != "" {
 			params.Add("severity[lte]", opts.SeverityLte)
+		}
+		for _, typeID := range opts.IncidentTypeOneOf {
+			params.Add("incident_type[one_of]", typeID)
 		}
 		if opts.CreatedAtGte != "" {
 			params.Add("created_at[gte]", opts.CreatedAtGte)

--- a/internal/client/incidents_test.go
+++ b/internal/client/incidents_test.go
@@ -55,6 +55,41 @@ func TestListIncidents(t *testing.T) {
 			expectedCount:  0,
 		},
 		{
+			name: "filter by incident type",
+			params: &ListIncidentsOptions{
+				IncidentTypeOneOf: []string{"type_security"},
+			},
+			mockResponse: `{
+				"incidents": [
+					{
+						"id": "inc_sec",
+						"reference": "INC-100",
+						"name": "Security incident",
+						"incident_status": {
+							"id": "status_active",
+							"name": "Active"
+						},
+						"severity": {
+							"id": "sev_1",
+							"name": "Critical"
+						},
+						"incident_type": {
+							"id": "type_security",
+							"name": "Security"
+						},
+						"created_at": "2024-01-01T00:00:00Z",
+						"updated_at": "2024-01-01T01:00:00Z"
+					}
+				],
+				"pagination_info": {
+					"page_size": 25
+				}
+			}`,
+			mockStatusCode: http.StatusOK,
+			wantError:      false,
+			expectedCount:  1,
+		},
+		{
 			name: "filter by severity",
 			params: &ListIncidentsOptions{
 				Severity: []string{"sev_1", "sev_2"},
@@ -106,6 +141,12 @@ func TestListIncidents(t *testing.T) {
 								t.Errorf("expected %d status values, got %d", len(tt.params.Status), len(statusValues))
 							}
 						}
+						if len(tt.params.IncidentTypeOneOf) > 0 {
+							typeValues := req.URL.Query()["incident_type[one_of]"]
+							if len(typeValues) != len(tt.params.IncidentTypeOneOf) {
+								t.Errorf("expected %d incident_type values, got %d", len(tt.params.IncidentTypeOneOf), len(typeValues))
+							}
+						}
 					}
 
 					return mockResponse(tt.mockStatusCode, tt.mockResponse), nil
@@ -132,6 +173,9 @@ func TestListIncidents(t *testing.T) {
 					assertEqual(t, "inc_123", incident.ID)
 					assertEqual(t, "INC-123", incident.Reference)
 					assertEqual(t, "Database outage", incident.Name)
+				case "filter by incident type":
+					assertEqual(t, "inc_sec", incident.ID)
+					assertEqual(t, "type_security", incident.IncidentType.ID)
 				case "filter by severity":
 					assertEqual(t, "inc_456", incident.ID)
 					assertEqual(t, "sev_2", incident.Severity.ID)

--- a/internal/handlers/incidents.go
+++ b/internal/handlers/incidents.go
@@ -27,14 +27,16 @@ func (t *ListIncidentsTool) Description() string {
 		"KEY FEATURES:\n" +
 		"- search: Filter by name (e.g., search='speechify' finds all Speechify incidents)\n" +
 		"- summary: true (default) returns compact summaries, false returns full details\n" +
-		"- page_size: Default 25, increase only if needed\n\n" +
+		"- page_size: Default 25, increase only if needed\n" +
+		"- incident_type_id: Filter by incident type IDs (use list_incident_types to get IDs)\n\n" +
 		"RESPONSE FORMAT (summary=true, default):\n" +
 		"Returns: reference, name, status, severity, created_at, updated_at, permalink\n" +
 		"This is much smaller than full incident objects!\n\n" +
 		"EXAMPLES:\n" +
 		"Find Speechify incidents: list_incidents({\"search\": \"speechify\"})\n" +
 		"Recent incidents: list_incidents({\"created_at_gte\": \"2025-01-28\"})\n" +
-		"Full details: list_incidents({\"search\": \"speechify\", \"summary\": false})\n\n" +
+		"Full details: list_incidents({\"search\": \"speechify\", \"summary\": false})\n" +
+		"Filter by type: list_incidents({\"incident_type_id\": [\"01ABC123\"]})\n\n" +
 		"PAGINATION:\n" +
 		"If has_more_results=true, call again with 'after' cursor from pagination_meta.\n\n" +
 		"INCIDENT REFERENCE RESOLUTION:\n" +
@@ -107,6 +109,11 @@ func (t *ListIncidentsTool) InputSchema() map[string]interface{} {
 			"custom_field_value": map[string]interface{}{
 				"type":        "string",
 				"description": "Custom field OPTION ID to match. For select fields, this must be the option's ID (e.g., '01JQ7...'), not the label. Get from the options array of search_custom_fields response.",
+			},
+			"incident_type_id": map[string]interface{}{
+				"type":        "array",
+				"items":       map[string]interface{}{"type": "string"},
+				"description": "Filter by incident type IDs. Use list_incident_types to get IDs. Example: ['01ABC123']",
 			},
 		},
 	}
@@ -186,6 +193,14 @@ func (t *ListIncidentsTool) Execute(args map[string]interface{}) (string, error)
 
 	if updatedAtLte, ok := args["updated_at_lte"].(string); ok && updatedAtLte != "" {
 		opts.UpdatedAtLte = updatedAtLte
+	}
+
+	if typeIDs, ok := args["incident_type_id"].([]interface{}); ok {
+		for _, id := range typeIDs {
+			if str, ok := id.(string); ok {
+				opts.IncidentTypeOneOf = append(opts.IncidentTypeOneOf, str)
+			}
+		}
 	}
 
 	// Handle custom field filtering - API format: custom_field[ID][one_of]=option_id


### PR DESCRIPTION
### Why?

Filtering incidents by type is a common analytical need (e.g. "all Security incidents in the last 90 days"), but without this filter the only option is to fetch every incident with full details and discard non-matching ones client-side. In practice this meant 8 paginated API calls (~2 MB/page) to retrieve 347 incidents just to find 29 of type Security — a full table scan for what should be a single targeted query.

The incident.io API already documents `incident_type[one_of]` as a supported filter on the List Incidents endpoint, so this is purely a case of the MCP layer not yet exposing a capability the API already has.

### How?

Add `IncidentTypeOneOf []string` to `ListIncidentsOptions`, wire it to the `incident_type[one_of]` query parameter in the client, and expose it as an `incident_type_id` array parameter on the `list_incidents` MCP tool — following the identical pattern already used for `severity[one_of]` and `status[one_of]`.

<details>
<summary>Implementation Plan</summary>

# Plan: Add `incident_type` filter to `list_incidents`

## Context

When querying "all Security-type incidents from the last 90 days", there's no way to filter by `incident_type` in `list_incidents`. The only workaround is fetching ALL incidents with `summary: false` (full detail, ~2MB/page), paginating through all of them, and filtering client-side with jq — 8 API round-trips for what should be a single filtered query.

The incident.io API **confirms** `incident_type[one_of]` as a documented query parameter ([API docs](https://docs.incident.io/api-reference/incidents-v2/list.md)), supporting both `one_of` and `not_in` operators — exactly the same shape as `severity[one_of]` / `status[one_of]`. The MCP server just doesn't expose it yet.

## Files to Change

| File | Change |
|---|---|
| `internal/client/incidents.go` | Add `IncidentTypeOneOf []string` field to `ListIncidentsOptions`; add query param loop |
| `internal/handlers/incidents.go` | Add `incident_type_id` to `InputSchema()`; parse it in `Execute()`; update description |
| `internal/client/incidents_test.go` | Add test case for `incident_type[one_of]` query param |

</details>

<sub>Generated with Claude Code</sub>