### PR TITLE
Fix critical performance and correctness issues across client and han…

### DIFF
--- a/internal/client/actions.go
+++ b/internal/client/actions.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -23,7 +24,7 @@ type ListActionsResponse struct {
 
 // ListActions retrieves a single page of actions
 // Pagination is controlled by the caller using PageSize and After parameters
-func (c *Client) ListActions(opts *ListActionsOptions) (*ListActionsResponse, error) {
+func (c *Client) ListActions(ctx context.Context, opts *ListActionsOptions) (*ListActionsResponse, error) {
 	pageSize := 10 // Conservative default to avoid exceeding MCP client limits
 	after := ""
 
@@ -52,7 +53,7 @@ func (c *Client) ListActions(opts *ListActionsOptions) (*ListActionsResponse, er
 		}
 	}
 
-	respBody, err := c.doRequest("GET", "/actions", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/actions", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -66,8 +67,8 @@ func (c *Client) ListActions(opts *ListActionsOptions) (*ListActionsResponse, er
 }
 
 // GetAction retrieves a specific action by ID
-func (c *Client) GetAction(id string) (*Action, error) {
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/actions/%s", id), nil, nil)
+func (c *Client) GetAction(ctx context.Context, id string) (*Action, error) {
+	respBody, err := c.doRequest(ctx, "GET", fmt.Sprintf("/actions/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/alert_events.go
+++ b/internal/client/alert_events.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -16,10 +17,10 @@ type CreateAlertEventRequest struct {
 }
 
 // CreateAlertEvent creates a new alert event
-func (c *Client) CreateAlertEvent(req *CreateAlertEventRequest) (*AlertEvent, error) {
+func (c *Client) CreateAlertEvent(ctx context.Context, req *CreateAlertEventRequest) (*AlertEvent, error) {
 	endpoint := "/alert_events/http"
 
-	respBody, err := c.doRequest("POST", endpoint, nil, req)
+	respBody, err := c.doRequest(ctx, "POST", endpoint, nil, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/alert_events_test.go
+++ b/internal/client/alert_events_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -154,7 +155,7 @@ func TestCreateAlertEvent(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			event, err := client.CreateAlertEvent(tt.request)
+			event, err := client.CreateAlertEvent(context.Background(), tt.request)
 
 			if tt.wantError {
 				assertError(t, err)

--- a/internal/client/alert_routes.go
+++ b/internal/client/alert_routes.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -22,7 +23,7 @@ type ListAlertRoutesResponse struct {
 }
 
 // ListAlertRoutes returns all alert routes
-func (c *Client) ListAlertRoutes(params *ListAlertRoutesParams) (*ListAlertRoutesResponse, error) {
+func (c *Client) ListAlertRoutes(ctx context.Context, params *ListAlertRoutesParams) (*ListAlertRoutesResponse, error) {
 	endpoint := "/alert_routes"
 
 	// Set default page size
@@ -41,7 +42,7 @@ func (c *Client) ListAlertRoutes(params *ListAlertRoutesParams) (*ListAlertRoute
 		endpoint = endpoint + "?" + v.Encode()
 	}
 
-	respBody, err := c.doRequest("GET", endpoint, nil, nil)
+	respBody, err := c.doRequest(ctx, "GET", endpoint, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -55,10 +56,10 @@ func (c *Client) ListAlertRoutes(params *ListAlertRoutesParams) (*ListAlertRoute
 }
 
 // GetAlertRoute returns a specific alert route by ID
-func (c *Client) GetAlertRoute(id string) (*AlertRoute, error) {
+func (c *Client) GetAlertRoute(ctx context.Context, id string) (*AlertRoute, error) {
 	endpoint := fmt.Sprintf("/alert_routes/%s", id)
 
-	respBody, err := c.doRequest("GET", endpoint, nil, nil)
+	respBody, err := c.doRequest(ctx, "GET", endpoint, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -84,10 +85,10 @@ type CreateAlertRouteRequest struct {
 }
 
 // CreateAlertRoute creates a new alert route
-func (c *Client) CreateAlertRoute(req *CreateAlertRouteRequest) (*AlertRoute, error) {
+func (c *Client) CreateAlertRoute(ctx context.Context, req *CreateAlertRouteRequest) (*AlertRoute, error) {
 	endpoint := "/alert_routes"
 
-	respBody, err := c.doRequest("POST", endpoint, nil, req)
+	respBody, err := c.doRequest(ctx, "POST", endpoint, nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,10 +114,10 @@ type UpdateAlertRouteRequest struct {
 }
 
 // UpdateAlertRoute updates an alert route
-func (c *Client) UpdateAlertRoute(id string, req *UpdateAlertRouteRequest) (*AlertRoute, error) {
+func (c *Client) UpdateAlertRoute(ctx context.Context, id string, req *UpdateAlertRouteRequest) (*AlertRoute, error) {
 	endpoint := fmt.Sprintf("/alert_routes/%s", id)
 
-	respBody, err := c.doRequest("PATCH", endpoint, nil, req)
+	respBody, err := c.doRequest(ctx, "PATCH", endpoint, nil, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/alert_routes_test.go
+++ b/internal/client/alert_routes_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -75,7 +76,7 @@ func TestListAlertRoutes(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			result, err := client.ListAlertRoutes(tt.params)
+			result, err := client.ListAlertRoutes(context.Background(), tt.params)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -174,7 +175,7 @@ func TestGetAlertRoute(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			route, err := client.GetAlertRoute(tt.routeID)
+			route, err := client.GetAlertRoute(context.Background(), tt.routeID)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -316,7 +317,7 @@ func TestCreateAlertRoute(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			route, err := client.CreateAlertRoute(tt.request)
+			route, err := client.CreateAlertRoute(context.Background(), tt.request)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -427,7 +428,7 @@ func TestUpdateAlertRoute(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			route, err := client.UpdateAlertRoute(tt.routeID, tt.request)
+			route, err := client.UpdateAlertRoute(context.Background(), tt.routeID, tt.request)
 
 			if tt.wantError {
 				assertError(t, err)

--- a/internal/client/alert_sources.go
+++ b/internal/client/alert_sources.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -33,7 +34,7 @@ type ListAlertSourcesResponse struct {
 }
 
 // ListAlertSources returns all alert sources
-func (c *Client) ListAlertSources(params *ListAlertSourcesParams) (*ListAlertSourcesResponse, error) {
+func (c *Client) ListAlertSources(ctx context.Context, params *ListAlertSourcesParams) (*ListAlertSourcesResponse, error) {
 	endpoint := "/alert_sources"
 
 	// Set default page size
@@ -52,7 +53,7 @@ func (c *Client) ListAlertSources(params *ListAlertSourcesParams) (*ListAlertSou
 		endpoint = endpoint + "?" + v.Encode()
 	}
 
-	respBody, err := c.doRequest("GET", endpoint, nil, nil)
+	respBody, err := c.doRequest(ctx, "GET", endpoint, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/alert_sources_test.go
+++ b/internal/client/alert_sources_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -104,7 +105,7 @@ func TestListAlertSources(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			result, err := client.ListAlertSources(tt.params)
+			result, err := client.ListAlertSources(context.Background(), tt.params)
 
 			if tt.wantError {
 				assertError(t, err)

--- a/internal/client/alerts.go
+++ b/internal/client/alerts.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -40,7 +41,7 @@ type ListIncidentAlertsResponse struct {
 
 // ListAlerts retrieves a single page of alerts
 // Pagination is controlled by the caller using PageSize and After parameters
-func (c *Client) ListAlerts(opts *ListAlertsOptions) (*ListAlertsResponse, error) {
+func (c *Client) ListAlerts(ctx context.Context, opts *ListAlertsOptions) (*ListAlertsResponse, error) {
 	pageSize := 25 // API default page size
 	after := ""
 
@@ -80,7 +81,7 @@ func (c *Client) ListAlerts(opts *ListAlertsOptions) (*ListAlertsResponse, error
 		}
 	}
 
-	respBody, err := c.doRequest("GET", "/alerts", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/alerts", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +95,8 @@ func (c *Client) ListAlerts(opts *ListAlertsOptions) (*ListAlertsResponse, error
 }
 
 // GetAlert retrieves a specific alert by ID
-func (c *Client) GetAlert(id string) (*Alert, error) {
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/alerts/%s", id), nil, nil)
+func (c *Client) GetAlert(ctx context.Context, id string) (*Alert, error) {
+	respBody, err := c.doRequest(ctx, "GET", fmt.Sprintf("/alerts/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +113,7 @@ func (c *Client) GetAlert(id string) (*Alert, error) {
 
 // ListIncidentAlerts retrieves a single page of incident alerts
 // Pagination is controlled by the caller using PageSize and After parameters
-func (c *Client) ListIncidentAlerts(opts *ListIncidentAlertsOptions) (*ListIncidentAlertsResponse, error) {
+func (c *Client) ListIncidentAlerts(ctx context.Context, opts *ListIncidentAlertsOptions) (*ListIncidentAlertsResponse, error) {
 	pageSize := 25 // Default page size as per API documentation
 	after := ""
 
@@ -141,7 +142,7 @@ func (c *Client) ListIncidentAlerts(opts *ListIncidentAlertsOptions) (*ListIncid
 		}
 	}
 
-	respBody, err := c.doRequest("GET", "/incident_alerts", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/incident_alerts", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/catalog.go
+++ b/internal/client/catalog.go
@@ -1,19 +1,15 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 )
 
 // ListCatalogTypes returns all catalog types
-func (c *Client) ListCatalogTypes() (*ListCatalogTypesResponse, error) {
-	// Catalog API uses V3, need to temporarily change the base URL
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v3")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
-	respBody, err := c.doRequest("GET", "/catalog_types", nil, nil)
+func (c *Client) ListCatalogTypes(ctx context.Context) (*ListCatalogTypesResponse, error) {
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV3, "GET", "/catalog_types", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +31,7 @@ type ListCatalogEntriesOptions struct {
 }
 
 // ListCatalogEntries returns catalog entries for a given type
-func (c *Client) ListCatalogEntries(opts ListCatalogEntriesOptions) (*ListCatalogEntriesResponse, error) {
-	// Catalog API uses V3, need to temporarily change the base URL
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v3")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
+func (c *Client) ListCatalogEntries(ctx context.Context, opts ListCatalogEntriesOptions) (*ListCatalogEntriesResponse, error) {
 	// Set default page_size if not provided (required by API)
 	pageSize := opts.PageSize
 	if pageSize == 0 {
@@ -59,7 +50,7 @@ func (c *Client) ListCatalogEntries(opts ListCatalogEntriesOptions) (*ListCatalo
 		params.Set("identifier", opts.Identifier)
 	}
 
-	respBody, err := c.doRequest("GET", "/catalog_entries", params, nil)
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV3, "GET", "/catalog_entries", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -73,13 +64,8 @@ func (c *Client) ListCatalogEntries(opts ListCatalogEntriesOptions) (*ListCatalo
 }
 
 // UpdateCatalogEntry updates a catalog entry by ID
-func (c *Client) UpdateCatalogEntry(id string, req UpdateCatalogEntryRequest) (*CatalogEntry, error) {
-	// Catalog API uses V3, need to temporarily change the base URL
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v3")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
-	respBody, err := c.doRequest("PUT", fmt.Sprintf("/catalog_entries/%s", id), nil, req)
+func (c *Client) UpdateCatalogEntry(ctx context.Context, id string, req UpdateCatalogEntryRequest) (*CatalogEntry, error) {
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV3, "PUT", fmt.Sprintf("/catalog_entries/%s", id), nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -95,13 +81,8 @@ func (c *Client) UpdateCatalogEntry(id string, req UpdateCatalogEntryRequest) (*
 }
 
 // GetCatalogEntry retrieves a specific catalog entry by ID
-func (c *Client) GetCatalogEntry(id string) (*CatalogEntry, error) {
-	// Catalog API uses V3, need to temporarily change the base URL
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v3")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/catalog_entries/%s", id), nil, nil)
+func (c *Client) GetCatalogEntry(ctx context.Context, id string) (*CatalogEntry, error) {
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV3, "GET", fmt.Sprintf("/catalog_entries/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -14,6 +15,8 @@ import (
 
 const (
 	defaultBaseURL = "https://api.incident.io/v2"
+	BaseURLV1      = "https://api.incident.io/v1"
+	BaseURLV3      = "https://api.incident.io/v3"
 	userAgent      = "incidentio-mcp-server/0.1.0"
 )
 
@@ -21,6 +24,7 @@ type Client struct {
 	httpClient *http.Client
 	baseURL    string
 	apiKey     string
+	debug      bool
 }
 
 func NewClient() (*Client, error) {
@@ -34,44 +38,52 @@ func NewClient() (*Client, error) {
 		baseURL = defaultBaseURL
 	}
 
+	// Clone the default transport to preserve HTTP/2 support, connection pooling,
+	// TLS handshake timeout, and other production-ready defaults.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
 	return &Client{
 		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					MinVersion: tls.VersionTLS12,
-				},
-			},
+			Timeout:   30 * time.Second,
+			Transport: transport,
 		},
 		baseURL: baseURL,
 		apiKey:  apiKey,
+		debug:   os.Getenv("MCP_DEBUG") != "",
 	}, nil
 }
 
-// BaseURL returns the current base URL
-func (c *Client) BaseURL() string {
-	return c.baseURL
+// DoRequest exposes the internal doRequest method using the default base URL
+func (c *Client) DoRequest(ctx context.Context, method, path string, params url.Values, body interface{}) ([]byte, error) {
+	return c.doRequestWithBase(ctx, c.baseURL, method, path, params, body)
 }
 
-// SetBaseURL sets the base URL
-func (c *Client) SetBaseURL(baseURL string) {
-	c.baseURL = baseURL
+// DoRequestV1 makes a request against the V1 API
+func (c *Client) DoRequestV1(ctx context.Context, method, path string, params url.Values, body interface{}) ([]byte, error) {
+	return c.doRequestWithBase(ctx, BaseURLV1, method, path, params, body)
 }
 
-// DoRequest exposes the internal doRequest method
-func (c *Client) DoRequest(method, path string, params url.Values, body interface{}) ([]byte, error) {
-	return c.doRequest(method, path, params, body)
+// DoRequestV3 makes a request against the V3 API
+func (c *Client) DoRequestV3(ctx context.Context, method, path string, params url.Values, body interface{}) ([]byte, error) {
+	return c.doRequestWithBase(ctx, BaseURLV3, method, path, params, body)
 }
 
-func (c *Client) doRequest(method, path string, params url.Values, body interface{}) ([]byte, error) {
-	endpoint := c.baseURL + path
+func (c *Client) doRequest(ctx context.Context, method, path string, params url.Values, body interface{}) ([]byte, error) {
+	return c.doRequestWithBase(ctx, c.baseURL, method, path, params, body)
+}
+
+func (c *Client) doRequestWithBase(ctx context.Context, baseURL, method, path string, params url.Values, body interface{}) ([]byte, error) {
+	endpoint := baseURL + path
 
 	if len(params) > 0 {
 		endpoint += "?" + params.Encode()
 	}
 
 	// Debug logging to stderr (won't interfere with MCP protocol)
-	if os.Getenv("MCP_DEBUG") != "" {
+	if c.debug {
 		fmt.Fprintf(os.Stderr, "[DEBUG] %s %s\n", method, endpoint)
 	}
 
@@ -84,7 +96,7 @@ func (c *Client) doRequest(method, path string, params url.Values, body interfac
 		reqBody = bytes.NewReader(jsonBody)
 	}
 
-	req, err := http.NewRequest(method, endpoint, reqBody)
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/client/client_critical_test.go
+++ b/internal/client/client_critical_test.go
@@ -1,0 +1,218 @@
+package client
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Test 1: Transport configuration - Clone preserves HTTP/2, TLS 1.2, timeouts
+func TestTransportConfiguration(t *testing.T) {
+	t.Setenv("INCIDENT_IO_API_KEY", "test-key")
+	t.Setenv("MCP_DEBUG", "")
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	transport, ok := c.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+
+	// TLS minimum version should be 1.2
+	if transport.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig is nil")
+	}
+	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Errorf("TLS MinVersion = %d, want %d", transport.TLSClientConfig.MinVersion, tls.VersionTLS12)
+	}
+
+	// Clone from DefaultTransport should preserve these defaults
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+
+	if transport.MaxIdleConns != defaultTransport.MaxIdleConns {
+		t.Errorf("MaxIdleConns = %d, want %d", transport.MaxIdleConns, defaultTransport.MaxIdleConns)
+	}
+	if transport.IdleConnTimeout != defaultTransport.IdleConnTimeout {
+		t.Errorf("IdleConnTimeout = %v, want %v", transport.IdleConnTimeout, defaultTransport.IdleConnTimeout)
+	}
+	if transport.TLSHandshakeTimeout != defaultTransport.TLSHandshakeTimeout {
+		t.Errorf("TLSHandshakeTimeout = %v, want %v", transport.TLSHandshakeTimeout, defaultTransport.TLSHandshakeTimeout)
+	}
+	if transport.ForceAttemptHTTP2 != defaultTransport.ForceAttemptHTTP2 {
+		t.Errorf("ForceAttemptHTTP2 = %v, want %v", transport.ForceAttemptHTTP2, defaultTransport.ForceAttemptHTTP2)
+	}
+
+	// Client-level timeout
+	if c.httpClient.Timeout != 30*time.Second {
+		t.Errorf("Client.Timeout = %v, want 30s", c.httpClient.Timeout)
+	}
+}
+
+// Test 2: Context cancellation propagates to HTTP request
+func TestContextCancellationPropagates(t *testing.T) {
+	// Server that blocks until the test is done
+	blocked := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-blocked
+	}))
+	defer srv.Close()
+	defer close(blocked)
+
+	c := &Client{
+		httpClient: srv.Client(),
+		baseURL:    srv.URL,
+		apiKey:     "test-key",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := c.DoRequest(ctx, "GET", "/test", nil, nil)
+		errCh <- err
+	}()
+
+	// Cancel the context while the request is in flight
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected error from cancelled context")
+		}
+		if !strings.Contains(err.Error(), "context canceled") {
+			t.Errorf("expected context canceled error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("request did not respect context cancellation within 5s")
+	}
+}
+
+// Test 3: Concurrent client calls are safe (no race on baseURL)
+func TestConcurrentClientCallsSafe(t *testing.T) {
+	// Run with -race to detect data races
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		httpClient: srv.Client(),
+		baseURL:    srv.URL,
+		apiKey:     "test-key",
+	}
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	const numGoroutines = 50
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Mix of DoRequest, DoRequestV1, DoRequestV3
+			c.DoRequest(ctx, "GET", "/default", nil, nil)
+			c.DoRequestV1(ctx, "GET", "/v1path", nil, nil)
+			c.DoRequestV3(ctx, "GET", "/v3path", nil, nil)
+		}()
+	}
+
+	wg.Wait()
+}
+
+// Test 4: Version-specific routing - V1/V3 calls hit correct base URL
+func TestVersionSpecificRouting(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   func(c *Client, ctx context.Context) ([]byte, error)
+		wantBase string
+	}{
+		{
+			name: "DoRequest uses default base URL",
+			method: func(c *Client, ctx context.Context) ([]byte, error) {
+				return c.DoRequest(ctx, "GET", "/test", nil, nil)
+			},
+			wantBase: defaultBaseURL,
+		},
+		{
+			name: "DoRequestV1 uses V1 base URL",
+			method: func(c *Client, ctx context.Context) ([]byte, error) {
+				return c.DoRequestV1(ctx, "GET", "/test", nil, nil)
+			},
+			wantBase: BaseURLV1,
+		},
+		{
+			name: "DoRequestV3 uses V3 base URL",
+			method: func(c *Client, ctx context.Context) ([]byte, error) {
+				return c.DoRequestV3(ctx, "GET", "/test", nil, nil)
+			},
+			wantBase: BaseURLV3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedURL string
+			mock := &MockHTTPClient{
+				DoFunc: func(req *http.Request) (*http.Response, error) {
+					capturedURL = req.URL.String()
+					return mockResponse(200, `{}`), nil
+				},
+			}
+
+			c := &Client{
+				httpClient: &http.Client{Transport: mock},
+				baseURL:    defaultBaseURL,
+				apiKey:     "test-key",
+			}
+
+			_, err := tt.method(c, context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !strings.HasPrefix(capturedURL, tt.wantBase) {
+				t.Errorf("URL = %q, want prefix %q", capturedURL, tt.wantBase)
+			}
+		})
+	}
+}
+
+// Test 5: Debug flag cached at construction time
+func TestDebugFlagCachedAtConstruction(t *testing.T) {
+	// Set MCP_DEBUG before construction
+	t.Setenv("INCIDENT_IO_API_KEY", "test-key")
+	t.Setenv("MCP_DEBUG", "1")
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if !c.debug {
+		t.Error("debug should be true when MCP_DEBUG is set at construction")
+	}
+
+	// Unset MCP_DEBUG after construction - client should still have debug=true
+	t.Setenv("MCP_DEBUG", "")
+	if !c.debug {
+		t.Error("debug should remain true after unsetting MCP_DEBUG (cached at construction)")
+	}
+
+	// Create another client without MCP_DEBUG
+	c2, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if c2.debug {
+		t.Error("debug should be false when MCP_DEBUG is not set at construction")
+	}
+}

--- a/internal/client/custom_fields.go
+++ b/internal/client/custom_fields.go
@@ -1,14 +1,15 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
 )
 
 // ListCustomFields retrieves all custom fields
-func (c *Client) ListCustomFields() (*ListCustomFieldsResponse, error) {
-	respBody, err := c.doRequest("GET", "/custom_fields", nil, nil)
+func (c *Client) ListCustomFields(ctx context.Context) (*ListCustomFieldsResponse, error) {
+	respBody, err := c.doRequest(ctx, "GET", "/custom_fields", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -22,8 +23,8 @@ func (c *Client) ListCustomFields() (*ListCustomFieldsResponse, error) {
 }
 
 // GetCustomField retrieves a specific custom field by ID
-func (c *Client) GetCustomField(id string) (*CustomField, error) {
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/custom_fields/%s", id), nil, nil)
+func (c *Client) GetCustomField(ctx context.Context, id string) (*CustomField, error) {
+	respBody, err := c.doRequest(ctx, "GET", fmt.Sprintf("/custom_fields/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +40,8 @@ func (c *Client) GetCustomField(id string) (*CustomField, error) {
 }
 
 // CreateCustomField creates a new custom field
-func (c *Client) CreateCustomField(req *CreateCustomFieldRequest) (*CustomField, error) {
-	respBody, err := c.doRequest("POST", "/custom_fields", nil, req)
+func (c *Client) CreateCustomField(ctx context.Context, req *CreateCustomFieldRequest) (*CustomField, error) {
+	respBody, err := c.doRequest(ctx, "POST", "/custom_fields", nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +57,8 @@ func (c *Client) CreateCustomField(req *CreateCustomFieldRequest) (*CustomField,
 }
 
 // UpdateCustomField updates an existing custom field
-func (c *Client) UpdateCustomField(id string, req *UpdateCustomFieldRequest) (*CustomField, error) {
-	respBody, err := c.doRequest("PUT", fmt.Sprintf("/custom_fields/%s", id), nil, req)
+func (c *Client) UpdateCustomField(ctx context.Context, id string, req *UpdateCustomFieldRequest) (*CustomField, error) {
+	respBody, err := c.doRequest(ctx, "PUT", fmt.Sprintf("/custom_fields/%s", id), nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -73,14 +74,14 @@ func (c *Client) UpdateCustomField(id string, req *UpdateCustomFieldRequest) (*C
 }
 
 // DeleteCustomField deletes a custom field
-func (c *Client) DeleteCustomField(id string) error {
-	_, err := c.doRequest("DELETE", fmt.Sprintf("/custom_fields/%s", id), nil, nil)
+func (c *Client) DeleteCustomField(ctx context.Context, id string) error {
+	_, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("/custom_fields/%s", id), nil, nil)
 	return err
 }
 
 // ListCustomFieldOptions retrieves all options for custom fields
-func (c *Client) ListCustomFieldOptions() ([]CustomFieldOption, error) {
-	respBody, err := c.doRequest("GET", "/custom_field_options", nil, nil)
+func (c *Client) ListCustomFieldOptions(ctx context.Context) ([]CustomFieldOption, error) {
+	respBody, err := c.doRequest(ctx, "GET", "/custom_field_options", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -96,8 +97,8 @@ func (c *Client) ListCustomFieldOptions() ([]CustomFieldOption, error) {
 }
 
 // GetCustomFieldOption retrieves a specific custom field option by ID
-func (c *Client) GetCustomFieldOption(id string) (*CustomFieldOption, error) {
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/custom_field_options/%s", id), nil, nil)
+func (c *Client) GetCustomFieldOption(ctx context.Context, id string) (*CustomFieldOption, error) {
+	respBody, err := c.doRequest(ctx, "GET", fmt.Sprintf("/custom_field_options/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -113,8 +114,8 @@ func (c *Client) GetCustomFieldOption(id string) (*CustomFieldOption, error) {
 }
 
 // CreateCustomFieldOption creates a new custom field option
-func (c *Client) CreateCustomFieldOption(req *CreateCustomFieldOptionRequest) (*CustomFieldOption, error) {
-	respBody, err := c.doRequest("POST", "/custom_field_options", nil, req)
+func (c *Client) CreateCustomFieldOption(ctx context.Context, req *CreateCustomFieldOptionRequest) (*CustomFieldOption, error) {
+	respBody, err := c.doRequest(ctx, "POST", "/custom_field_options", nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -130,8 +131,8 @@ func (c *Client) CreateCustomFieldOption(req *CreateCustomFieldOptionRequest) (*
 }
 
 // UpdateCustomFieldOption updates an existing custom field option
-func (c *Client) UpdateCustomFieldOption(id string, req *UpdateCustomFieldOptionRequest) (*CustomFieldOption, error) {
-	respBody, err := c.doRequest("PUT", fmt.Sprintf("/custom_field_options/%s", id), nil, req)
+func (c *Client) UpdateCustomFieldOption(ctx context.Context, id string, req *UpdateCustomFieldOptionRequest) (*CustomFieldOption, error) {
+	respBody, err := c.doRequest(ctx, "PUT", fmt.Sprintf("/custom_field_options/%s", id), nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -147,13 +148,13 @@ func (c *Client) UpdateCustomFieldOption(id string, req *UpdateCustomFieldOption
 }
 
 // DeleteCustomFieldOption deletes a custom field option
-func (c *Client) DeleteCustomFieldOption(id string) error {
-	_, err := c.doRequest("DELETE", fmt.Sprintf("/custom_field_options/%s", id), nil, nil)
+func (c *Client) DeleteCustomFieldOption(ctx context.Context, id string) error {
+	_, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("/custom_field_options/%s", id), nil, nil)
 	return err
 }
 
 // SearchCustomFields searches for custom fields by name or field type
-func (c *Client) SearchCustomFields(query string, fieldType string) ([]CustomField, error) {
+func (c *Client) SearchCustomFields(ctx context.Context, query string, fieldType string) ([]CustomField, error) {
 	params := url.Values{}
 	if query != "" {
 		params.Set("query", query)
@@ -162,7 +163,7 @@ func (c *Client) SearchCustomFields(query string, fieldType string) ([]CustomFie
 		params.Set("field_type", fieldType)
 	}
 
-	respBody, err := c.doRequest("GET", "/custom_fields", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/custom_fields", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/custom_fields_test.go
+++ b/internal/client/custom_fields_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -74,7 +75,7 @@ func TestListCustomFields(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			result, err := client.ListCustomFields()
+			result, err := client.ListCustomFields(context.Background())
 
 			if tt.wantError {
 				assertError(t, err)
@@ -159,7 +160,7 @@ func TestGetCustomField(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			field, err := client.GetCustomField(tt.fieldID)
+			field, err := client.GetCustomField(context.Background(), tt.fieldID)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -272,7 +273,7 @@ func TestCreateCustomField(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			field, err := client.CreateCustomField(tt.request)
+			field, err := client.CreateCustomField(context.Background(), tt.request)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -358,7 +359,7 @@ func TestUpdateCustomField(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			field, err := client.UpdateCustomField(tt.fieldID, tt.request)
+			field, err := client.UpdateCustomField(context.Background(), tt.fieldID, tt.request)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -407,7 +408,7 @@ func TestDeleteCustomField(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			err := client.DeleteCustomField(tt.fieldID)
+			err := client.DeleteCustomField(context.Background(), tt.fieldID)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -470,7 +471,7 @@ func TestListCustomFieldOptions(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			options, err := client.ListCustomFieldOptions()
+			options, err := client.ListCustomFieldOptions(context.Background())
 
 			if tt.wantError {
 				assertError(t, err)
@@ -535,7 +536,7 @@ func TestCreateCustomFieldOption(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			option, err := client.CreateCustomFieldOption(tt.request)
+			option, err := client.CreateCustomFieldOption(context.Background(), tt.request)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -628,7 +629,7 @@ func TestSearchCustomFields(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			fields, err := client.SearchCustomFields(tt.query, tt.fieldType)
+			fields, err := client.SearchCustomFields(context.Background(), tt.query, tt.fieldType)
 
 			if tt.wantError {
 				assertError(t, err)

--- a/internal/client/follow_ups.go
+++ b/internal/client/follow_ups.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -18,7 +19,7 @@ type ListFollowUpsResponse struct {
 }
 
 // ListFollowUps retrieves all follow-ups for an organization
-func (c *Client) ListFollowUps(opts *ListFollowUpsOptions) (*ListFollowUpsResponse, error) {
+func (c *Client) ListFollowUps(ctx context.Context, opts *ListFollowUpsOptions) (*ListFollowUpsResponse, error) {
 	params := url.Values{}
 
 	if opts != nil {
@@ -30,7 +31,7 @@ func (c *Client) ListFollowUps(opts *ListFollowUpsOptions) (*ListFollowUpsRespon
 		}
 	}
 
-	respBody, err := c.doRequest("GET", "/follow_ups", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/follow_ups", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -44,8 +45,8 @@ func (c *Client) ListFollowUps(opts *ListFollowUpsOptions) (*ListFollowUpsRespon
 }
 
 // GetFollowUp retrieves a specific follow-up by ID
-func (c *Client) GetFollowUp(id string) (*FollowUp, error) {
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/follow_ups/%s", id), nil, nil)
+func (c *Client) GetFollowUp(ctx context.Context, id string) (*FollowUp, error) {
+	respBody, err := c.doRequest(ctx, "GET", fmt.Sprintf("/follow_ups/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/incident_types.go
+++ b/internal/client/incident_types.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -13,8 +14,8 @@ type ListIncidentTypesResponse struct {
 }
 
 // ListIncidentTypes returns all incident types
-func (c *Client) ListIncidentTypes() (*ListIncidentTypesResponse, error) {
-	respBody, err := c.doRequest("GET", "/incident_types", nil, nil)
+func (c *Client) ListIncidentTypes(ctx context.Context) (*ListIncidentTypesResponse, error) {
+	respBody, err := c.doRequest(ctx, "GET", "/incident_types", nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/incident_updates.go
+++ b/internal/client/incident_updates.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -8,7 +9,7 @@ import (
 )
 
 // ListIncidentUpdates retrieves incident updates with optional filtering
-func (c *Client) ListIncidentUpdates(opts *ListIncidentUpdatesOptions) (*ListIncidentUpdatesResponse, error) {
+func (c *Client) ListIncidentUpdates(ctx context.Context, opts *ListIncidentUpdatesOptions) (*ListIncidentUpdatesResponse, error) {
 	// Set default page size
 	pageSize := 25
 	if opts != nil && opts.PageSize > 0 {
@@ -27,7 +28,7 @@ func (c *Client) ListIncidentUpdates(opts *ListIncidentUpdatesOptions) (*ListInc
 		}
 	}
 
-	respBody, err := c.doRequest("GET", "/incident_updates", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/incident_updates", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -41,8 +42,8 @@ func (c *Client) ListIncidentUpdates(opts *ListIncidentUpdatesOptions) (*ListInc
 }
 
 // GetIncidentUpdate retrieves a specific incident update by ID
-func (c *Client) GetIncidentUpdate(id string) (*IncidentUpdate, error) {
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/incident_updates/%s", id), nil, nil)
+func (c *Client) GetIncidentUpdate(ctx context.Context, id string) (*IncidentUpdate, error) {
+	respBody, err := c.doRequest(ctx, "GET", fmt.Sprintf("/incident_updates/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (c *Client) GetIncidentUpdate(id string) (*IncidentUpdate, error) {
 }
 
 // CreateIncidentUpdate creates a new incident update
-func (c *Client) CreateIncidentUpdate(req *CreateIncidentUpdateRequest) (*IncidentUpdate, error) {
+func (c *Client) CreateIncidentUpdate(ctx context.Context, req *CreateIncidentUpdateRequest) (*IncidentUpdate, error) {
 	// Validate required fields
 	if req.IncidentID == "" {
 		return nil, fmt.Errorf("incident_id is required")
@@ -67,7 +68,7 @@ func (c *Client) CreateIncidentUpdate(req *CreateIncidentUpdateRequest) (*Incide
 		return nil, fmt.Errorf("message is required")
 	}
 
-	respBody, err := c.doRequest("POST", "/incident_updates", nil, req)
+	respBody, err := c.doRequest(ctx, "POST", "/incident_updates", nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func (c *Client) CreateIncidentUpdate(req *CreateIncidentUpdateRequest) (*Incide
 }
 
 // DeleteIncidentUpdate deletes an incident update
-func (c *Client) DeleteIncidentUpdate(id string) error {
-	_, err := c.doRequest("DELETE", fmt.Sprintf("/incident_updates/%s", id), nil, nil)
+func (c *Client) DeleteIncidentUpdate(ctx context.Context, id string) error {
+	_, err := c.doRequest(ctx, "DELETE", fmt.Sprintf("/incident_updates/%s", id), nil, nil)
 	return err
 }

--- a/internal/client/incidents.go
+++ b/internal/client/incidents.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -36,7 +37,7 @@ type ListIncidentsResponse struct {
 
 // ListIncidents retrieves a single page of incidents
 // Pagination is controlled by the caller using PageSize and After parameters
-func (c *Client) ListIncidents(opts *ListIncidentsOptions) (*ListIncidentsResponse, error) {
+func (c *Client) ListIncidents(ctx context.Context, opts *ListIncidentsOptions) (*ListIncidentsResponse, error) {
 	pageSize := 10 // Conservative default to avoid exceeding MCP client limits
 	after := ""
 
@@ -99,7 +100,7 @@ func (c *Client) ListIncidents(opts *ListIncidentsOptions) (*ListIncidentsRespon
 		}
 	}
 
-	respBody, err := c.doRequest("GET", "/incidents", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/incidents", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -113,8 +114,8 @@ func (c *Client) ListIncidents(opts *ListIncidentsOptions) (*ListIncidentsRespon
 }
 
 // GetIncident retrieves a specific incident by ID
-func (c *Client) GetIncident(id string) (*Incident, error) {
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/incidents/%s", id), nil, nil)
+func (c *Client) GetIncident(ctx context.Context, id string) (*Incident, error) {
+	respBody, err := c.doRequest(ctx, "GET", fmt.Sprintf("/incidents/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -130,8 +131,8 @@ func (c *Client) GetIncident(id string) (*Incident, error) {
 }
 
 // CreateIncident creates a new incident
-func (c *Client) CreateIncident(req *CreateIncidentRequest) (*Incident, error) {
-	respBody, err := c.doRequest("POST", "/incidents", nil, req)
+func (c *Client) CreateIncident(ctx context.Context, req *CreateIncidentRequest) (*Incident, error) {
+	respBody, err := c.doRequest(ctx, "POST", "/incidents", nil, req)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func (c *Client) CreateIncident(req *CreateIncidentRequest) (*Incident, error) {
 }
 
 // UpdateIncident updates an existing incident using V2 actions/edit API
-func (c *Client) UpdateIncident(id string, req *UpdateIncidentRequest) (*Incident, error) {
+func (c *Client) UpdateIncident(ctx context.Context, id string, req *UpdateIncidentRequest) (*Incident, error) {
 	// Use the correct V2 actions/edit endpoint
 	editRequest := map[string]interface{}{
 		"notify_incident_channel": true,
@@ -191,7 +192,7 @@ func (c *Client) UpdateIncident(id string, req *UpdateIncidentRequest) (*Inciden
 		return nil, fmt.Errorf("no fields to update")
 	}
 
-	respBody, err := c.doRequest("POST", fmt.Sprintf("/incidents/%s/actions/edit", id), nil, editRequest)
+	respBody, err := c.doRequest(ctx, "POST", fmt.Sprintf("/incidents/%s/actions/edit", id), nil, editRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -213,8 +214,8 @@ type AssignIncidentRoleRequest struct {
 }
 
 // AssignIncidentRole assigns a specific role to a user for an incident
-func (c *Client) AssignIncidentRole(incidentID string, req *AssignIncidentRoleRequest) (*Incident, error) {
-	respBody, err := c.doRequest("PATCH", fmt.Sprintf("/incidents/%s", incidentID), nil, map[string]interface{}{
+func (c *Client) AssignIncidentRole(ctx context.Context, incidentID string, req *AssignIncidentRoleRequest) (*Incident, error) {
+	respBody, err := c.doRequest(ctx, "PATCH", fmt.Sprintf("/incidents/%s", incidentID), nil, map[string]interface{}{
 		"incident_role_assignments": []map[string]interface{}{
 			{
 				"incident_role_id": req.IncidentRoleID,

--- a/internal/client/incidents_test.go
+++ b/internal/client/incidents_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -154,7 +155,7 @@ func TestListIncidents(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			result, err := client.ListIncidents(tt.params)
+			result, err := client.ListIncidents(context.Background(), tt.params)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -250,7 +251,7 @@ func TestGetIncident(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			incident, err := client.GetIncident(tt.incidentID)
+			incident, err := client.GetIncident(context.Background(), tt.incidentID)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -391,7 +392,7 @@ func TestCreateIncident(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			incident, err := client.CreateIncident(tt.request)
+			incident, err := client.CreateIncident(context.Background(), tt.request)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -503,7 +504,7 @@ func TestUpdateIncident(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			incident, err := client.UpdateIncident(tt.incidentID, tt.request)
+			incident, err := client.UpdateIncident(context.Background(), tt.incidentID, tt.request)
 
 			if tt.wantError {
 				assertError(t, err)

--- a/internal/client/postmortems.go
+++ b/internal/client/postmortems.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -8,13 +9,7 @@ import (
 )
 
 // ListPostmortems retrieves all postmortem documents for an organization
-func (c *Client) ListPostmortems(opts *ListPostmortemsOptions) (*ListPostmortemsResponse, error) {
-	// Note: Postmortems are under V1 API, not V2
-	// We need to temporarily change the base URL for this request
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v1")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
+func (c *Client) ListPostmortems(ctx context.Context, opts *ListPostmortemsOptions) (*ListPostmortemsResponse, error) {
 	params := url.Values{}
 
 	if opts != nil {
@@ -32,7 +27,7 @@ func (c *Client) ListPostmortems(opts *ListPostmortemsOptions) (*ListPostmortems
 		}
 	}
 
-	respBody, err := c.doRequest("GET", "/postmortem_documents", params, nil)
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV1, "GET", "/postmortem_documents", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -46,14 +41,8 @@ func (c *Client) ListPostmortems(opts *ListPostmortemsOptions) (*ListPostmortems
 }
 
 // GetPostmortem retrieves a specific postmortem document by ID
-func (c *Client) GetPostmortem(id string) (*PostmortemDocument, error) {
-	// Note: Postmortems are under V1 API, not V2
-	// We need to temporarily change the base URL for this request
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v1")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/postmortem_documents/%s", id), nil, nil)
+func (c *Client) GetPostmortem(ctx context.Context, id string) (*PostmortemDocument, error) {
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV1, "GET", fmt.Sprintf("/postmortem_documents/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -69,14 +58,8 @@ func (c *Client) GetPostmortem(id string) (*PostmortemDocument, error) {
 }
 
 // GetPostmortemContent retrieves the markdown content of a postmortem document
-func (c *Client) GetPostmortemContent(id string) (*PostmortemContentResponse, error) {
-	// Note: Postmortems are under V1 API, not V2
-	// We need to temporarily change the base URL for this request
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v1")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/postmortem_documents/%s/content", id), nil, nil)
+func (c *Client) GetPostmortemContent(ctx context.Context, id string) (*PostmortemContentResponse, error) {
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV1, "GET", fmt.Sprintf("/postmortem_documents/%s/content", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/roles.go
+++ b/internal/client/roles.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -73,7 +74,7 @@ type ListUsersResponse struct {
 }
 
 // ListIncidentRoles retrieves a list of incident roles
-func (c *Client) ListIncidentRoles(opts *ListIncidentRolesOptions) (*ListIncidentRolesResponse, error) {
+func (c *Client) ListIncidentRoles(ctx context.Context, opts *ListIncidentRolesOptions) (*ListIncidentRolesResponse, error) {
 	// Set default page size
 	pageSize := 25
 	if opts != nil && opts.PageSize > 0 {
@@ -87,7 +88,7 @@ func (c *Client) ListIncidentRoles(opts *ListIncidentRolesOptions) (*ListInciden
 		params.Set("after", opts.After)
 	}
 
-	respBody, err := c.doRequest("GET", "/incident_roles", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/incident_roles", params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +103,7 @@ func (c *Client) ListIncidentRoles(opts *ListIncidentRolesOptions) (*ListInciden
 
 // ListUsers retrieves a single page of users
 // Pagination is controlled by the caller using PageSize and After parameters
-func (c *Client) ListUsers(opts *ListUsersOptions) (*ListUsersResponse, error) {
+func (c *Client) ListUsers(ctx context.Context, opts *ListUsersOptions) (*ListUsersResponse, error) {
 	pageSize := 10 // Conservative default to avoid exceeding MCP client limits
 	after := ""
 
@@ -126,7 +127,7 @@ func (c *Client) ListUsers(opts *ListUsersOptions) (*ListUsersResponse, error) {
 		params.Set("email", opts.Email)
 	}
 
-	respBody, err := c.doRequest("GET", "/users", params, nil)
+	respBody, err := c.doRequest(ctx, "GET", "/users", params, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/severities.go
+++ b/internal/client/severities.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -13,14 +14,8 @@ type ListSeveritiesResponse struct {
 }
 
 // ListSeverities returns all severities
-func (c *Client) ListSeverities() (*ListSeveritiesResponse, error) {
-	// Note: Severities are under V1 API, not V2
-	// We need to temporarily change the base URL for this request
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v1")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
-	respBody, err := c.doRequest("GET", "/severities", nil, nil)
+func (c *Client) ListSeverities(ctx context.Context) (*ListSeveritiesResponse, error) {
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV1, "GET", "/severities", nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -34,14 +29,8 @@ func (c *Client) ListSeverities() (*ListSeveritiesResponse, error) {
 }
 
 // GetSeverity retrieves a specific severity by ID
-func (c *Client) GetSeverity(id string) (*Severity, error) {
-	// Note: Severities are under V1 API, not V2
-	// We need to temporarily change the base URL for this request
-	originalBaseURL := c.BaseURL()
-	c.SetBaseURL("https://api.incident.io/v1")
-	defer func() { c.SetBaseURL(originalBaseURL) }()
-
-	respBody, err := c.doRequest("GET", fmt.Sprintf("/severities/%s", id), nil, nil)
+func (c *Client) GetSeverity(ctx context.Context, id string) (*Severity, error) {
+	respBody, err := c.doRequestWithBase(ctx, BaseURLV1, "GET", fmt.Sprintf("/severities/%s", id), nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/workflows.go
+++ b/internal/client/workflows.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -22,7 +23,7 @@ type ListWorkflowsResponse struct {
 }
 
 // ListWorkflows returns all workflows
-func (c *Client) ListWorkflows(params *ListWorkflowsParams) (*ListWorkflowsResponse, error) {
+func (c *Client) ListWorkflows(ctx context.Context, params *ListWorkflowsParams) (*ListWorkflowsResponse, error) {
 	endpoint := "/workflows"
 
 	// Set default page size
@@ -41,7 +42,7 @@ func (c *Client) ListWorkflows(params *ListWorkflowsParams) (*ListWorkflowsRespo
 		endpoint = endpoint + "?" + v.Encode()
 	}
 
-	respBody, err := c.doRequest("GET", endpoint, nil, nil)
+	respBody, err := c.doRequest(ctx, "GET", endpoint, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -55,10 +56,10 @@ func (c *Client) ListWorkflows(params *ListWorkflowsParams) (*ListWorkflowsRespo
 }
 
 // GetWorkflow returns a specific workflow by ID
-func (c *Client) GetWorkflow(id string) (*Workflow, error) {
+func (c *Client) GetWorkflow(ctx context.Context, id string) (*Workflow, error) {
 	endpoint := fmt.Sprintf("/workflows/%s", id)
 
-	respBody, err := c.doRequest("GET", endpoint, nil, nil)
+	respBody, err := c.doRequest(ctx, "GET", endpoint, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -81,10 +82,10 @@ type UpdateWorkflowRequest struct {
 }
 
 // UpdateWorkflow updates a workflow
-func (c *Client) UpdateWorkflow(id string, req *UpdateWorkflowRequest) (*Workflow, error) {
+func (c *Client) UpdateWorkflow(ctx context.Context, id string, req *UpdateWorkflowRequest) (*Workflow, error) {
 	endpoint := fmt.Sprintf("/workflows/%s", id)
 
-	respBody, err := c.doRequest("PATCH", endpoint, nil, req)
+	respBody, err := c.doRequest(ctx, "PATCH", endpoint, nil, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/workflows_test.go
+++ b/internal/client/workflows_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -75,7 +76,7 @@ func TestListWorkflows(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			result, err := client.ListWorkflows(tt.params)
+			result, err := client.ListWorkflows(context.Background(), tt.params)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -146,7 +147,7 @@ func TestGetWorkflow(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			workflow, err := client.GetWorkflow(tt.workflowID)
+			workflow, err := client.GetWorkflow(context.Background(), tt.workflowID)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -234,7 +235,7 @@ func TestUpdateWorkflow(t *testing.T) {
 			}
 
 			client := NewTestClient(mockClient)
-			workflow, err := client.UpdateWorkflow(tt.workflowID, tt.request)
+			workflow, err := client.UpdateWorkflow(context.Background(), tt.workflowID, tt.request)
 
 			if tt.wantError {
 				assertError(t, err)
@@ -306,7 +307,7 @@ func TestWorkflowTriggerObjectParsing(t *testing.T) {
 	}
 
 	client := NewTestClient(mockClient)
-	result, err := client.ListWorkflows(nil)
+	result, err := client.ListWorkflows(context.Background(), nil)
 
 	assertNoError(t, err)
 	if len(result.Workflows) != 2 {

--- a/internal/handlers/actions.go
+++ b/internal/handlers/actions.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/incident-io/incidentio-mcp-golang/internal/client"
@@ -52,7 +53,7 @@ func (t *ListActionsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListActionsTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListActionsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListActionsOptions{
 		PageSize: GetIntArg(args, "page_size", 10), // Default to small page size to avoid exceeding Claude's 1MB limit
 		After:    GetStringArg(args, "after"),
@@ -64,7 +65,7 @@ func (t *ListActionsTool) Execute(args map[string]interface{}) (string, error) {
 
 	opts.Status = GetStringArrayArg(args, "status")
 
-	resp, err := t.apiClient.ListActions(opts)
+	resp, err := t.apiClient.ListActions(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -114,13 +115,13 @@ func (t *GetActionTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetActionTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetActionTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id := GetStringArg(args, "id")
 	if id == "" {
 		return "", fmt.Errorf("id parameter is required")
 	}
 
-	action, err := t.apiClient.GetAction(id)
+	action, err := t.apiClient.GetAction(ctx, id)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/alert_events.go
+++ b/internal/handlers/alert_events.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -62,7 +63,7 @@ func (t *CreateAlertEventTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *CreateAlertEventTool) Execute(args map[string]interface{}) (string, error) {
+func (t *CreateAlertEventTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	req := &client.CreateAlertEventRequest{}
 
 	alertSourceID, ok := args["alert_source_id"].(string)
@@ -95,7 +96,7 @@ func (t *CreateAlertEventTool) Execute(args map[string]interface{}) (string, err
 		req.Metadata = metadata
 	}
 
-	alertEvent, err := t.apiClient.CreateAlertEvent(req)
+	alertEvent, err := t.apiClient.CreateAlertEvent(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("failed to create alert event: %w", err)
 	}

--- a/internal/handlers/alert_routes.go
+++ b/internal/handlers/alert_routes.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -43,7 +44,7 @@ func (t *ListAlertRoutesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListAlertRoutesTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListAlertRoutesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	params := &client.ListAlertRoutesParams{}
 
 	if pageSize, ok := args["page_size"].(float64); ok {
@@ -53,7 +54,7 @@ func (t *ListAlertRoutesTool) Execute(args map[string]interface{}) (string, erro
 		params.After = after
 	}
 
-	result, err := t.apiClient.ListAlertRoutes(params)
+	result, err := t.apiClient.ListAlertRoutes(ctx, params)
 	if err != nil {
 		return "", fmt.Errorf("failed to list alert routes: %w", err)
 	}
@@ -98,13 +99,13 @@ func (t *GetAlertRouteTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetAlertRouteTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetAlertRouteTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("alert route ID is required")
 	}
 
-	alertRoute, err := t.apiClient.GetAlertRoute(id)
+	alertRoute, err := t.apiClient.GetAlertRoute(ctx, id)
 	if err != nil {
 		return "", fmt.Errorf("failed to get alert route: %w", err)
 	}
@@ -205,7 +206,7 @@ func (t *CreateAlertRouteTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *CreateAlertRouteTool) Execute(args map[string]interface{}) (string, error) {
+func (t *CreateAlertRouteTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	req := &client.CreateAlertRouteRequest{}
 
 	name, ok := args["name"].(string)
@@ -261,7 +262,7 @@ func (t *CreateAlertRouteTool) Execute(args map[string]interface{}) (string, err
 		req.Template = template
 	}
 
-	alertRoute, err := t.apiClient.CreateAlertRoute(req)
+	alertRoute, err := t.apiClient.CreateAlertRoute(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("failed to create alert route: %w", err)
 	}
@@ -365,7 +366,7 @@ func (t *UpdateAlertRouteTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *UpdateAlertRouteTool) Execute(args map[string]interface{}) (string, error) {
+func (t *UpdateAlertRouteTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("alert route ID is required")
@@ -425,7 +426,7 @@ func (t *UpdateAlertRouteTool) Execute(args map[string]interface{}) (string, err
 		req.Template = template
 	}
 
-	alertRoute, err := t.apiClient.UpdateAlertRoute(id, req)
+	alertRoute, err := t.apiClient.UpdateAlertRoute(ctx, id, req)
 	if err != nil {
 		return "", fmt.Errorf("failed to update alert route: %w", err)
 	}

--- a/internal/handlers/alert_sources.go
+++ b/internal/handlers/alert_sources.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -43,7 +44,7 @@ func (t *ListAlertSourcesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListAlertSourcesTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListAlertSourcesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	params := &client.ListAlertSourcesParams{}
 
 	if pageSize, ok := args["page_size"].(float64); ok {
@@ -53,7 +54,7 @@ func (t *ListAlertSourcesTool) Execute(args map[string]interface{}) (string, err
 		params.After = after
 	}
 
-	result, err := t.apiClient.ListAlertSources(params)
+	result, err := t.apiClient.ListAlertSources(ctx, params)
 	if err != nil {
 		return "", fmt.Errorf("failed to list alert sources: %w", err)
 	}

--- a/internal/handlers/alerts.go
+++ b/internal/handlers/alerts.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -93,7 +94,7 @@ func (t *ListAlertsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListAlertsTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListAlertsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListAlertsOptions{
 		PageSize: GetIntArg(args, "page_size", 25), // Use API default page size
 		After:    GetStringArg(args, "after"),
@@ -109,7 +110,7 @@ func (t *ListAlertsTool) Execute(args map[string]interface{}) (string, error) {
 	opts.CreatedAtLte = GetStringArg(args, "created_at_lte")
 	opts.CreatedAtDateRange = GetStringArg(args, "created_at_date_range")
 
-	resp, err := t.apiClient.ListAlerts(opts)
+	resp, err := t.apiClient.ListAlerts(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -167,13 +168,13 @@ func (t *GetAlertTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetAlertTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetAlertTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok {
 		return "", fmt.Errorf("id parameter is required")
 	}
 
-	alert, err := t.apiClient.GetAlert(id)
+	alert, err := t.apiClient.GetAlert(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -241,7 +242,7 @@ func (t *ListIncidentAlertsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListIncidentAlertsTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListIncidentAlertsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListIncidentAlertsOptions{
 		PageSize: 25, // Default page size
 	}
@@ -265,7 +266,7 @@ func (t *ListIncidentAlertsTool) Execute(args map[string]interface{}) (string, e
 	// Note: According to API docs, both incident_id and alert_id are optional
 	// If neither is provided, all incident-alert connections will be returned
 
-	resp, err := t.apiClient.ListIncidentAlerts(opts)
+	resp, err := t.apiClient.ListIncidentAlerts(ctx, opts)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/catalog.go
+++ b/internal/handlers/catalog.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -34,8 +35,8 @@ func (t *ListCatalogTypesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListCatalogTypesTool) Execute(args map[string]interface{}) (string, error) {
-	result, err := t.apiClient.ListCatalogTypes()
+func (t *ListCatalogTypesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
+	result, err := t.apiClient.ListCatalogTypes(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to list catalog types: %w", err)
 	}
@@ -130,7 +131,7 @@ func (t *ListCatalogEntriesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListCatalogEntriesTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListCatalogEntriesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	catalogTypeID, ok := args["catalog_type_id"].(string)
 	if !ok || catalogTypeID == "" {
 		return "", fmt.Errorf("catalog_type_id parameter is required")
@@ -158,7 +159,7 @@ func (t *ListCatalogEntriesTool) Execute(args map[string]interface{}) (string, e
 		opts.Identifier = identifier
 	}
 
-	result, err := t.apiClient.ListCatalogEntries(opts)
+	result, err := t.apiClient.ListCatalogEntries(ctx, opts)
 	if err != nil {
 		return "", fmt.Errorf("failed to list catalog entries: %w", err)
 	}
@@ -282,7 +283,7 @@ func (t *UpdateCatalogEntryTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *UpdateCatalogEntryTool) Execute(args map[string]interface{}) (string, error) {
+func (t *UpdateCatalogEntryTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("id parameter is required")
@@ -363,7 +364,7 @@ func (t *UpdateCatalogEntryTool) Execute(args map[string]interface{}) (string, e
 		}
 	}
 
-	result, err := t.apiClient.UpdateCatalogEntry(id, req)
+	result, err := t.apiClient.UpdateCatalogEntry(ctx, id, req)
 	if err != nil {
 		return "", fmt.Errorf("failed to update catalog entry: %w", err)
 	}

--- a/internal/handlers/close_incident.go
+++ b/internal/handlers/close_incident.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -37,14 +38,14 @@ func (t *CloseIncidentTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *CloseIncidentTool) Execute(args map[string]interface{}) (string, error) {
+func (t *CloseIncidentTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok {
 		return "", fmt.Errorf("id parameter is required")
 	}
 
 	// Get the current incident first
-	incident, err := t.apiClient.GetIncident(id)
+	incident, err := t.apiClient.GetIncident(ctx, id)
 	if err != nil {
 		return "", fmt.Errorf("failed to get incident: %w", err)
 	}
@@ -63,7 +64,7 @@ func (t *CloseIncidentTool) Execute(args map[string]interface{}) (string, error)
 		IncidentStatusID: closedStatusID,
 	}
 
-	updatedIncident, err := t.apiClient.UpdateIncident(id, req)
+	updatedIncident, err := t.apiClient.UpdateIncident(ctx, id, req)
 	if err != nil {
 		// If direct closure fails, provide helpful guidance
 		return fmt.Sprintf(`Failed to close incident directly: %v

--- a/internal/handlers/create_incident_enhanced.go
+++ b/internal/handlers/create_incident_enhanced.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -72,7 +73,7 @@ func (t *CreateIncidentEnhancedTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *CreateIncidentEnhancedTool) Execute(args map[string]interface{}) (string, error) {
+func (t *CreateIncidentEnhancedTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	name, ok := args["name"].(string)
 	if !ok {
 		return "", fmt.Errorf("name parameter is required")
@@ -124,7 +125,7 @@ func (t *CreateIncidentEnhancedTool) Execute(args map[string]interface{}) (strin
 
 	// Auto-fetch severity if not provided
 	if req.SeverityID == "" {
-		severities, err := t.apiClient.ListSeverities()
+		severities, err := t.apiClient.ListSeverities(ctx)
 		if err == nil && len(severities.Severities) > 0 {
 			// Select the first severity (usually the least severe)
 			req.SeverityID = severities.Severities[len(severities.Severities)-1].ID
@@ -136,7 +137,7 @@ func (t *CreateIncidentEnhancedTool) Execute(args map[string]interface{}) (strin
 
 	// Auto-fetch incident type if not provided
 	if req.IncidentTypeID == "" {
-		types, err := t.apiClient.ListIncidentTypes()
+		types, err := t.apiClient.ListIncidentTypes(ctx)
 		if err == nil && len(types.IncidentTypes) > 0 {
 			// Select the first incident type
 			req.IncidentTypeID = types.IncidentTypes[0].ID
@@ -148,13 +149,7 @@ func (t *CreateIncidentEnhancedTool) Execute(args map[string]interface{}) (strin
 
 	// Auto-fetch incident status if not provided using V1 API
 	if req.IncidentStatusID == "" {
-		// Use V1 API to get incident statuses
-		originalBaseURL := t.apiClient.BaseURL()
-		t.apiClient.SetBaseURL("https://api.incident.io/v1")
-
-		respBody, err := t.apiClient.DoRequest("GET", "/incident_statuses", nil, nil)
-		t.apiClient.SetBaseURL(originalBaseURL) // Restore original URL
-
+		respBody, err := t.apiClient.DoRequestV1(ctx, "GET", "/incident_statuses", nil, nil)
 		if err == nil {
 			var statusResponse struct {
 				IncidentStatuses []struct {
@@ -185,7 +180,7 @@ func (t *CreateIncidentEnhancedTool) Execute(args map[string]interface{}) (strin
 	}
 
 	// Create the incident
-	incident, err := t.apiClient.CreateIncident(req)
+	incident, err := t.apiClient.CreateIncident(ctx, req)
 	if err != nil {
 		return "", fmt.Errorf("failed to create incident: %w", err)
 	}

--- a/internal/handlers/create_incident_enhanced_test.go
+++ b/internal/handlers/create_incident_enhanced_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -14,7 +15,7 @@ func TestCreateIncidentEnhancedTool_Execute(t *testing.T) {
 			"summary": "Test Summary",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing name parameter")
 		}
@@ -29,7 +30,7 @@ func TestCreateIncidentEnhancedTool_Execute(t *testing.T) {
 			"name": 123, // Not a string
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for wrong type name parameter")
 		}

--- a/internal/handlers/custom_fields.go
+++ b/internal/handlers/custom_fields.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,8 +33,8 @@ func (t *ListCustomFieldsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListCustomFieldsTool) Execute(args map[string]interface{}) (string, error) {
-	resp, err := t.apiClient.ListCustomFields()
+func (t *ListCustomFieldsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
+	resp, err := t.apiClient.ListCustomFields(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -76,13 +77,13 @@ func (t *GetCustomFieldTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetCustomFieldTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetCustomFieldTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("id parameter is required")
 	}
 
-	field, err := t.apiClient.GetCustomField(id)
+	field, err := t.apiClient.GetCustomField(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -140,11 +141,11 @@ func (t *SearchCustomFieldsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *SearchCustomFieldsTool) Execute(args map[string]interface{}) (string, error) {
+func (t *SearchCustomFieldsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	query := GetStringArg(args, "query")
 	fieldType := GetStringArg(args, "field_type")
 
-	fields, err := t.apiClient.SearchCustomFields(query, fieldType)
+	fields, err := t.apiClient.SearchCustomFields(ctx, query, fieldType)
 	if err != nil {
 		return "", err
 	}
@@ -222,7 +223,7 @@ func (t *CreateCustomFieldTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *CreateCustomFieldTool) Execute(args map[string]interface{}) (string, error) {
+func (t *CreateCustomFieldTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	name, ok := args["name"].(string)
 	if !ok || name == "" {
 		return "", fmt.Errorf("name is required")
@@ -278,7 +279,7 @@ func (t *CreateCustomFieldTool) Execute(args map[string]interface{}) (string, er
 		req.Options = options
 	}
 
-	field, err := t.apiClient.CreateCustomField(req)
+	field, err := t.apiClient.CreateCustomField(ctx, req)
 	if err != nil {
 		return "", err
 	}
@@ -350,7 +351,7 @@ func (t *UpdateCustomFieldTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *UpdateCustomFieldTool) Execute(args map[string]interface{}) (string, error) {
+func (t *UpdateCustomFieldTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("id is required")
@@ -392,7 +393,7 @@ func (t *UpdateCustomFieldTool) Execute(args map[string]interface{}) (string, er
 		req.Options = options
 	}
 
-	field, err := t.apiClient.UpdateCustomField(id, req)
+	field, err := t.apiClient.UpdateCustomField(ctx, id, req)
 	if err != nil {
 		return "", err
 	}
@@ -435,13 +436,13 @@ func (t *DeleteCustomFieldTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *DeleteCustomFieldTool) Execute(args map[string]interface{}) (string, error) {
+func (t *DeleteCustomFieldTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("id is required")
 	}
 
-	err := t.apiClient.DeleteCustomField(id)
+	err := t.apiClient.DeleteCustomField(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -473,8 +474,8 @@ func (t *ListCustomFieldOptionsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListCustomFieldOptionsTool) Execute(args map[string]interface{}) (string, error) {
-	options, err := t.apiClient.ListCustomFieldOptions()
+func (t *ListCustomFieldOptionsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
+	options, err := t.apiClient.ListCustomFieldOptions(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -523,7 +524,7 @@ func (t *CreateCustomFieldOptionTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *CreateCustomFieldOptionTool) Execute(args map[string]interface{}) (string, error) {
+func (t *CreateCustomFieldOptionTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	customFieldID, ok := args["custom_field_id"].(string)
 	if !ok || customFieldID == "" {
 		return "", fmt.Errorf("custom_field_id is required")
@@ -543,7 +544,7 @@ func (t *CreateCustomFieldOptionTool) Execute(args map[string]interface{}) (stri
 		req.SortKey = int(sortKey)
 	}
 
-	option, err := t.apiClient.CreateCustomFieldOption(req)
+	option, err := t.apiClient.CreateCustomFieldOption(ctx, req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/custom_fields_test.go
+++ b/internal/handlers/custom_fields_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 )
 
@@ -32,7 +33,7 @@ func TestGetCustomFieldTool_Execute(t *testing.T) {
 	t.Run("missing required id", func(t *testing.T) {
 		args := map[string]interface{}{}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing id parameter")
 		}
@@ -47,7 +48,7 @@ func TestGetCustomFieldTool_Execute(t *testing.T) {
 			"id": 123, // Not a string
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for wrong type id parameter")
 		}
@@ -59,7 +60,7 @@ func TestGetCustomFieldTool_Execute(t *testing.T) {
 			"id": "",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for empty id parameter")
 		}
@@ -142,7 +143,7 @@ func TestCreateCustomFieldTool_Execute(t *testing.T) {
 			"field_type":  "text",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing name parameter")
 		}
@@ -158,7 +159,7 @@ func TestCreateCustomFieldTool_Execute(t *testing.T) {
 			"field_type": "text",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing description parameter")
 		}
@@ -174,7 +175,7 @@ func TestCreateCustomFieldTool_Execute(t *testing.T) {
 			"description": "Test Description",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing field_type parameter")
 		}
@@ -191,7 +192,7 @@ func TestCreateCustomFieldTool_Execute(t *testing.T) {
 			"field_type":  "text",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for wrong type name parameter")
 		}
@@ -244,7 +245,7 @@ func TestUpdateCustomFieldTool_Execute(t *testing.T) {
 			"name": "Updated Name",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing id parameter")
 		}
@@ -260,7 +261,7 @@ func TestUpdateCustomFieldTool_Execute(t *testing.T) {
 			"name": "Updated Name",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for wrong type id parameter")
 		}
@@ -273,7 +274,7 @@ func TestUpdateCustomFieldTool_Execute(t *testing.T) {
 			"name": "Updated Name",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for empty id parameter")
 		}
@@ -318,7 +319,7 @@ func TestDeleteCustomFieldTool_Execute(t *testing.T) {
 	t.Run("missing required id", func(t *testing.T) {
 		args := map[string]interface{}{}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing id parameter")
 		}
@@ -333,7 +334,7 @@ func TestDeleteCustomFieldTool_Execute(t *testing.T) {
 			"id": 123, // Not a string
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for wrong type id parameter")
 		}
@@ -345,7 +346,7 @@ func TestDeleteCustomFieldTool_Execute(t *testing.T) {
 			"id": "",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for empty id parameter")
 		}
@@ -413,7 +414,7 @@ func TestCreateCustomFieldOptionTool_Execute(t *testing.T) {
 			"value": "Option Value",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing custom_field_id parameter")
 		}
@@ -428,7 +429,7 @@ func TestCreateCustomFieldOptionTool_Execute(t *testing.T) {
 			"custom_field_id": "cf_123",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing value parameter")
 		}
@@ -444,7 +445,7 @@ func TestCreateCustomFieldOptionTool_Execute(t *testing.T) {
 			"value":           "Option Value",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for wrong type custom_field_id parameter")
 		}
@@ -457,7 +458,7 @@ func TestCreateCustomFieldOptionTool_Execute(t *testing.T) {
 			"value":           "Option Value",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for empty custom_field_id parameter")
 		}

--- a/internal/handlers/follow_ups.go
+++ b/internal/handlers/follow_ups.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/incident-io/incidentio-mcp-golang/internal/client"
@@ -65,13 +66,13 @@ func (t *ListFollowUpsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListFollowUpsTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListFollowUpsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListFollowUpsOptions{
 		IncidentID:   t.ValidateOptionalString(args, "incident_id"),
 		IncidentMode: t.ValidateOptionalString(args, "incident_mode"),
 	}
 
-	resp, err := t.GetClient().ListFollowUps(opts)
+	resp, err := t.GetClient().ListFollowUps(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -129,13 +130,13 @@ func (t *GetFollowUpTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetFollowUpTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetFollowUpTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, err := t.ValidateRequiredString(args, "id")
 	if err != nil {
 		return "", err
 	}
 
-	followUp, err := t.GetClient().GetFollowUp(id)
+	followUp, err := t.GetClient().GetFollowUp(ctx, id)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/incident_statuses.go
+++ b/internal/handlers/incident_statuses.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -31,13 +32,8 @@ func (t *ListIncidentStatusesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListIncidentStatusesTool) Execute(args map[string]interface{}) (string, error) {
-	// Use V1 API to get incident statuses
-	originalBaseURL := t.apiClient.BaseURL()
-	t.apiClient.SetBaseURL("https://api.incident.io/v1")
-	defer t.apiClient.SetBaseURL(originalBaseURL)
-
-	respBody, err := t.apiClient.DoRequest("GET", "/incident_statuses", nil, nil)
+func (t *ListIncidentStatusesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
+	respBody, err := t.apiClient.DoRequestV1(ctx, "GET", "/incident_statuses", nil, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch incident statuses: %w", err)
 	}

--- a/internal/handlers/incident_types.go
+++ b/internal/handlers/incident_types.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,8 +33,8 @@ func (t *ListIncidentTypesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListIncidentTypesTool) Execute(args map[string]interface{}) (string, error) {
-	result, err := t.apiClient.ListIncidentTypes()
+func (t *ListIncidentTypesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
+	result, err := t.apiClient.ListIncidentTypes(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to list incident types: %w", err)
 	}

--- a/internal/handlers/incident_updates.go
+++ b/internal/handlers/incident_updates.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/incident-io/incidentio-mcp-golang/internal/client"
@@ -50,13 +51,13 @@ func (t *ListIncidentUpdatesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListIncidentUpdatesTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListIncidentUpdatesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListIncidentUpdatesOptions{
 		IncidentID: GetStringArg(args, "incident_id"),
 		PageSize:   GetIntArg(args, "page_size", 25),
 	}
 
-	resp, err := t.apiClient.ListIncidentUpdates(opts)
+	resp, err := t.apiClient.ListIncidentUpdates(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -95,13 +96,13 @@ func (t *GetIncidentUpdateTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetIncidentUpdateTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetIncidentUpdateTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id := GetStringArg(args, "id")
 	if id == "" {
 		return "", fmt.Errorf("id parameter is required")
 	}
 
-	update, err := t.apiClient.GetIncidentUpdate(id)
+	update, err := t.apiClient.GetIncidentUpdate(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -144,7 +145,7 @@ func (t *CreateIncidentUpdateTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *CreateIncidentUpdateTool) Execute(args map[string]interface{}) (string, error) {
+func (t *CreateIncidentUpdateTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	incidentID, ok := args["incident_id"].(string)
 	if !ok || incidentID == "" {
 		return "", fmt.Errorf("incident_id parameter is required")
@@ -160,7 +161,7 @@ func (t *CreateIncidentUpdateTool) Execute(args map[string]interface{}) (string,
 		Message:    message,
 	}
 
-	update, err := t.apiClient.CreateIncidentUpdate(req)
+	update, err := t.apiClient.CreateIncidentUpdate(ctx, req)
 	if err != nil {
 		return "", err
 	}
@@ -199,13 +200,13 @@ func (t *DeleteIncidentUpdateTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *DeleteIncidentUpdateTool) Execute(args map[string]interface{}) (string, error) {
+func (t *DeleteIncidentUpdateTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("id parameter is required")
 	}
 
-	if err := t.apiClient.DeleteIncidentUpdate(id); err != nil {
+	if err := t.apiClient.DeleteIncidentUpdate(ctx, id); err != nil {
 		return "", err
 	}
 

--- a/internal/handlers/incidents.go
+++ b/internal/handlers/incidents.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -130,7 +131,7 @@ type IncidentSummary struct {
 	Permalink  string `json:"permalink"`
 }
 
-func (t *ListIncidentsTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListIncidentsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListIncidentsOptions{
 		PageSize: 25, // Default to 25 for reasonable response sizes
 	}
@@ -213,7 +214,7 @@ func (t *ListIncidentsTool) Execute(args map[string]interface{}) (string, error)
 		}
 	}
 
-	resp, err := t.apiClient.ListIncidents(opts)
+	resp, err := t.apiClient.ListIncidents(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -337,7 +338,7 @@ func (t *GetIncidentTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetIncidentTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetIncidentTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["incident_id"].(string)
 	if !ok || id == "" {
 		argDetails := make(map[string]interface{})
@@ -347,7 +348,7 @@ func (t *GetIncidentTool) Execute(args map[string]interface{}) (string, error) {
 		return "", fmt.Errorf("incident_id parameter is required and must be a non-empty string. Received parameters: %+v", argDetails)
 	}
 
-	incident, err := t.apiClient.GetIncident(id)
+	incident, err := t.apiClient.GetIncident(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -428,7 +429,7 @@ func (t *CreateIncidentTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *CreateIncidentTool) Execute(args map[string]interface{}) (string, error) {
+func (t *CreateIncidentTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	name, ok := args["name"].(string)
 	if !ok {
 		return "", fmt.Errorf("name parameter is required")
@@ -481,7 +482,7 @@ func (t *CreateIncidentTool) Execute(args map[string]interface{}) (string, error
 		suggestions = append(suggestions, "incident_status_id is not set. Use list_incident_statuses to see available options.")
 	}
 
-	incident, err := t.apiClient.CreateIncident(req)
+	incident, err := t.apiClient.CreateIncident(ctx, req)
 	if err != nil {
 		// If the error is related to missing required fields, provide more helpful error message
 		errMsg := err.Error()
@@ -551,7 +552,7 @@ func (t *UpdateIncidentTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *UpdateIncidentTool) Execute(args map[string]interface{}) (string, error) {
+func (t *UpdateIncidentTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 
 	id, ok := args["incident_id"].(string)
 	if !ok || id == "" {
@@ -586,7 +587,7 @@ func (t *UpdateIncidentTool) Execute(args map[string]interface{}) (string, error
 		return "", fmt.Errorf("at least one field to update must be provided")
 	}
 
-	incident, err := t.apiClient.UpdateIncident(id, req)
+	incident, err := t.apiClient.UpdateIncident(ctx, id, req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/incidents_test.go
+++ b/internal/handlers/incidents_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 )
 
@@ -13,7 +14,7 @@ func TestCreateIncidentTool_Execute(t *testing.T) {
 			"summary": "Test Summary",
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for missing name parameter")
 		}
@@ -28,7 +29,7 @@ func TestCreateIncidentTool_Execute(t *testing.T) {
 			"name": 123, // Not a string
 		}
 
-		_, err := tool.Execute(args)
+		_, err := tool.Execute(context.Background(), args)
 		if err == nil {
 			t.Error("Expected error for wrong type name parameter")
 		}

--- a/internal/handlers/postmortems.go
+++ b/internal/handlers/postmortems.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/incident-io/incidentio-mcp-golang/internal/client"
@@ -66,7 +67,7 @@ func (t *ListPostmortemsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListPostmortemsTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListPostmortemsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListPostmortemsOptions{
 		PageSize:   t.ValidateOptionalInt(args, "page_size", 25),
 		After:      t.ValidateOptionalString(args, "after"),
@@ -74,7 +75,7 @@ func (t *ListPostmortemsTool) Execute(args map[string]interface{}) (string, erro
 		SortBy:     t.ValidateOptionalString(args, "sort_by"),
 	}
 
-	resp, err := t.GetClient().ListPostmortems(opts)
+	resp, err := t.GetClient().ListPostmortems(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -134,13 +135,13 @@ func (t *GetPostmortemTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetPostmortemTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetPostmortemTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, err := t.ValidateRequiredString(args, "id")
 	if err != nil {
 		return "", err
 	}
 
-	postmortem, err := t.GetClient().GetPostmortem(id)
+	postmortem, err := t.GetClient().GetPostmortem(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -190,13 +191,13 @@ func (t *GetPostmortemContentTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetPostmortemContentTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetPostmortemContentTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, err := t.ValidateRequiredString(args, "id")
 	if err != nil {
 		return "", err
 	}
 
-	content, err := t.GetClient().GetPostmortemContent(id)
+	content, err := t.GetClient().GetPostmortemContent(ctx, id)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/roles.go
+++ b/internal/handlers/roles.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -37,14 +38,14 @@ func (t *ListIncidentRolesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListIncidentRolesTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListIncidentRolesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListIncidentRolesOptions{}
 
 	if pageSize, ok := args["page_size"].(float64); ok {
 		opts.PageSize = int(pageSize)
 	}
 
-	resp, err := t.apiClient.ListIncidentRoles(opts)
+	resp, err := t.apiClient.ListIncidentRoles(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -92,7 +93,7 @@ func (t *ListUsersTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListUsersTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListUsersTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	opts := &client.ListUsersOptions{}
 
 	if pageSize, ok := args["page_size"].(float64); ok {
@@ -103,7 +104,7 @@ func (t *ListUsersTool) Execute(args map[string]interface{}) (string, error) {
 		opts.Email = email
 	}
 
-	resp, err := t.apiClient.ListUsers(opts)
+	resp, err := t.apiClient.ListUsers(ctx, opts)
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +173,7 @@ func (t *AssignIncidentRoleTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *AssignIncidentRoleTool) Execute(args map[string]interface{}) (string, error) {
+func (t *AssignIncidentRoleTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	argDetails := make(map[string]interface{})
 	for key, value := range args {
 		argDetails[key] = value
@@ -207,7 +208,7 @@ func (t *AssignIncidentRoleTool) Execute(args map[string]interface{}) (string, e
 		},
 	}
 
-	incident, err := t.apiClient.UpdateIncident(incidentID, req)
+	incident, err := t.apiClient.UpdateIncident(ctx, incidentID, req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/handlers/severities.go
+++ b/internal/handlers/severities.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -32,8 +33,8 @@ func (t *ListSeveritiesTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListSeveritiesTool) Execute(args map[string]interface{}) (string, error) {
-	result, err := t.apiClient.ListSeverities()
+func (t *ListSeveritiesTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
+	result, err := t.apiClient.ListSeverities(ctx)
 	if err != nil {
 		return "", fmt.Errorf("failed to list severities: %w", err)
 	}
@@ -91,13 +92,13 @@ func (t *GetSeverityTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetSeverityTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetSeverityTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("id parameter is required")
 	}
 
-	severity, err := t.apiClient.GetSeverity(id)
+	severity, err := t.apiClient.GetSeverity(ctx, id)
 	if err != nil {
 		return "", fmt.Errorf("failed to get severity: %w", err)
 	}

--- a/internal/handlers/tool.go
+++ b/internal/handlers/tool.go
@@ -1,9 +1,11 @@
 package handlers
 
+import "context"
+
 // Handler represents an MCP tool handler
 type Handler interface {
 	Name() string
 	Description() string
 	InputSchema() map[string]interface{}
-	Execute(args map[string]interface{}) (string, error)
+	Execute(ctx context.Context, args map[string]interface{}) (string, error)
 }

--- a/internal/handlers/workflows.go
+++ b/internal/handlers/workflows.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/incident-io/incidentio-mcp-golang/internal/client"
@@ -42,13 +43,13 @@ func (t *ListWorkflowsTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *ListWorkflowsTool) Execute(args map[string]interface{}) (string, error) {
+func (t *ListWorkflowsTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	params := &client.ListWorkflowsParams{
 		PageSize: GetIntArg(args, "page_size", 25),
 		After:    GetStringArg(args, "after"),
 	}
 
-	result, err := t.apiClient.ListWorkflows(params)
+	result, err := t.apiClient.ListWorkflows(ctx, params)
 	if err != nil {
 		return "", fmt.Errorf("failed to list workflows: %w", err)
 	}
@@ -88,13 +89,13 @@ func (t *GetWorkflowTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *GetWorkflowTool) Execute(args map[string]interface{}) (string, error) {
+func (t *GetWorkflowTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id := GetStringArg(args, "id")
 	if id == "" {
 		return "", fmt.Errorf("workflow ID is required")
 	}
 
-	workflow, err := t.apiClient.GetWorkflow(id)
+	workflow, err := t.apiClient.GetWorkflow(ctx, id)
 	if err != nil {
 		return "", fmt.Errorf("failed to get workflow: %w", err)
 	}
@@ -146,7 +147,7 @@ func (t *UpdateWorkflowTool) InputSchema() map[string]interface{} {
 	}
 }
 
-func (t *UpdateWorkflowTool) Execute(args map[string]interface{}) (string, error) {
+func (t *UpdateWorkflowTool) Execute(ctx context.Context, args map[string]interface{}) (string, error) {
 	id, ok := args["id"].(string)
 	if !ok || id == "" {
 		return "", fmt.Errorf("workflow ID is required")
@@ -166,7 +167,7 @@ func (t *UpdateWorkflowTool) Execute(args map[string]interface{}) (string, error
 		req.State = state
 	}
 
-	workflow, err := t.apiClient.UpdateWorkflow(id, req)
+	workflow, err := t.apiClient.UpdateWorkflow(ctx, id, req)
 	if err != nil {
 		return "", fmt.Errorf("failed to update workflow: %w", err)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,7 +34,7 @@ type Handler interface {
 	Name() string
 	Description() string
 	InputSchema() map[string]any
-	Execute(args map[string]any) (string, error)
+	Execute(ctx context.Context, args map[string]any) (string, error)
 }
 
 type Config struct {
@@ -111,7 +111,7 @@ func (s *Server) startStdioWithIO(ctx context.Context, in io.Reader, out io.Writ
 				continue
 			}
 
-			response, err := s.handleMessage(&decoded.msg)
+			response, err := s.handleMessage(ctx, &decoded.msg)
 			if err != nil {
 				response = s.createErrorResponse(decoded.msg.ID, err)
 			}
@@ -187,7 +187,7 @@ func (s *Server) handleHTTPMCP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response, err := s.handleMessage(&msg)
+	response, err := s.handleMessage(r.Context(), &msg)
 	if err != nil {
 		response = s.createErrorResponse(msg.ID, err)
 	}
@@ -220,7 +220,7 @@ func (s *Server) registerTools() {
 	s.mu.Unlock()
 }
 
-func (s *Server) handleMessage(msg *mcp.Message) (*mcp.Message, error) {
+func (s *Server) handleMessage(ctx context.Context, msg *mcp.Message) (*mcp.Message, error) {
 	// Handle notifications (no ID means it's a notification)
 	if msg.ID == nil {
 		return nil, nil
@@ -232,7 +232,7 @@ func (s *Server) handleMessage(msg *mcp.Message) (*mcp.Message, error) {
 	case "tools/list":
 		return s.handleToolsList(msg)
 	case "tools/call":
-		return s.handleToolCall(msg)
+		return s.handleToolCall(ctx, msg)
 	default:
 		return &mcp.Message{
 			Jsonrpc: "2.0",
@@ -286,7 +286,7 @@ func (s *Server) handleToolsList(msg *mcp.Message) (*mcp.Message, error) {
 	return response, nil
 }
 
-func (s *Server) handleToolCall(msg *mcp.Message) (*mcp.Message, error) {
+func (s *Server) handleToolCall(ctx context.Context, msg *mcp.Message) (*mcp.Message, error) {
 	params, ok := msg.Params.(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("invalid params")
@@ -307,7 +307,7 @@ func (s *Server) handleToolCall(msg *mcp.Message) (*mcp.Message, error) {
 
 	args, _ := params["arguments"].(map[string]interface{})
 
-	result, err := tool.Execute(args)
+	result, err := tool.Execute(ctx, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…dlers

- C1: Remove race condition on SetBaseURL by replacing shared mutable state with DoRequestV1/DoRequestV3 methods using constant base URLs
- C2: Clone http.DefaultTransport to preserve HTTP/2, connection pooling, and TLS handshake timeouts; cache MCP_DEBUG at construction time
- C3: Thread context.Context through entire call chain from server to HTTP requests, enabling proper cancellation and timeout propagation
- Add 5 tests covering transport config, context cancellation, concurrent safety (with -race), version-specific routing, and debug flag caching