### PR TITLE
feat: Add Escalations (paths and escalations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,15 @@ cp .env.example .env
 - `list_incidents` - List incidents with optional filters
 - `get_incident` - Get details of a specific incident
 - `create_incident` - Create a new incident
+- `create_incident_smart` - Create an incident with smart field resolution
 - `update_incident` - Update an existing incident
 - `close_incident` - Close an incident with proper workflow
+- `list_incident_statuses` - List available incident statuses
+- `list_incident_types` - List available incident types
+- `list_incident_updates` - List updates for an incident
+- `get_incident_update` - Get details of a specific incident update
 - `create_incident_update` - Post status updates to incidents
+- `delete_incident_update` - Delete an incident update
 
 ### Follow-up Management
 
@@ -105,14 +111,39 @@ cp .env.example .env
 - `list_alerts` - List alerts with optional filters
 - `get_alert` - Get details of a specific alert
 - `list_incident_alerts` - List connections between incidents and alerts
+- `list_alert_sources` - List available alert sources
 - `create_alert_event` - Create an alert event
-- `list_alert_routes` - List and manage alert routes
+- `list_alert_routes` - List alert routes
+- `get_alert_route` - Get details of a specific alert route
+- `create_alert_route` - Create a new alert route
+- `update_alert_route` - Update an existing alert route
+
+### Escalations
+
+- `list_escalation_paths` - List escalation paths in your account
+- `get_escalation_path` - Get details of a specific escalation path
+- `create_escalation_path` - Create a new escalation path
+- `update_escalation_path` - Update an existing escalation path
+- `destroy_escalation_path` - Delete an escalation path
+- `list_escalations` - List escalations
+- `get_escalation` - Get details of a specific escalation
+- `create_escalation` - Create a new escalation
+
+### Actions
+
+- `list_actions` - List actions with optional filters
+- `get_action` - Get details of a specific action
 
 ### Workflow & Automation
 
 - `list_workflows` - List available workflows
 - `get_workflow` - Get workflow details
 - `update_workflow` - Update workflow configuration
+
+### Severities
+
+- `list_severities` - List available severities
+- `get_severity` - Get details of a specific severity
 
 ### Team & Roles
 

--- a/internal/client/escalations.go
+++ b/internal/client/escalations.go
@@ -1,0 +1,268 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// ListEscalationPathsParams is query options for GET /escalation_paths.
+// See https://docs.incident.io/api-reference/escalations-v2/listpaths
+type ListEscalationPathsParams struct {
+	PageSize int
+	After    string
+}
+
+// ListEscalationPathsResponse is the API response for listing escalation paths.
+type ListEscalationPathsResponse struct {
+	EscalationPaths []json.RawMessage `json:"escalation_paths"`
+	PaginationMeta  struct {
+		After            string `json:"after,omitempty"`
+		PageSize         int    `json:"page_size"`
+		TotalRecordCount int    `json:"total_record_count,omitempty"`
+	} `json:"pagination_meta"`
+}
+
+// ListEscalationPaths lists escalation paths (On-call).
+func (c *Client) ListEscalationPaths(params *ListEscalationPathsParams) (*ListEscalationPathsResponse, error) {
+	pageSize := 25
+	if params != nil && params.PageSize > 0 {
+		pageSize = params.PageSize
+	}
+	if pageSize > 25 {
+		pageSize = 25
+	}
+
+	v := url.Values{}
+	v.Set("page_size", strconv.Itoa(pageSize))
+	if params != nil && params.After != "" {
+		v.Set("after", params.After)
+	}
+
+	endpoint := "/escalation_paths?" + v.Encode()
+	respBody, err := c.doRequest("GET", endpoint, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out ListEscalationPathsResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal escalation paths list: %w", err)
+	}
+	return &out, nil
+}
+
+// GetEscalationPath returns one escalation path by ID.
+func (c *Client) GetEscalationPath(id string) (json.RawMessage, error) {
+	if id == "" {
+		return nil, fmt.Errorf("escalation path id is required")
+	}
+	respBody, err := c.doRequest("GET", fmt.Sprintf("/escalation_paths/%s", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		EscalationPath json.RawMessage `json:"escalation_path"`
+	}
+	if err := json.Unmarshal(respBody, &wrap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal escalation path: %w", err)
+	}
+	return wrap.EscalationPath, nil
+}
+
+// CreateEscalationPath creates an escalation path. Body matches the API payload
+// (name, path, team_ids, repeat_config, working_hours, etc.).
+func (c *Client) CreateEscalationPath(body map[string]interface{}) (json.RawMessage, error) {
+	respBody, err := c.doRequest("POST", "/escalation_paths", nil, body)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		EscalationPath json.RawMessage `json:"escalation_path"`
+	}
+	if err := json.Unmarshal(respBody, &wrap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal create escalation path response: %w", err)
+	}
+	return wrap.EscalationPath, nil
+}
+
+// UpdateEscalationPath replaces an escalation path (PUT).
+func (c *Client) UpdateEscalationPath(id string, body map[string]interface{}) (json.RawMessage, error) {
+	if id == "" {
+		return nil, fmt.Errorf("escalation path id is required")
+	}
+	respBody, err := c.doRequest("PUT", fmt.Sprintf("/escalation_paths/%s", id), nil, body)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		EscalationPath json.RawMessage `json:"escalation_path"`
+	}
+	if err := json.Unmarshal(respBody, &wrap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal update escalation path response: %w", err)
+	}
+	return wrap.EscalationPath, nil
+}
+
+// DestroyEscalationPath archives an escalation path (DELETE, 204).
+func (c *Client) DestroyEscalationPath(id string) error {
+	if id == "" {
+		return fmt.Errorf("escalation path id is required")
+	}
+	_, err := c.doRequest("DELETE", fmt.Sprintf("/escalation_paths/%s", id), nil, nil)
+	return err
+}
+
+// ListEscalationsParams filters for GET /escalations.
+// See https://docs.incident.io/api-reference/escalations-v2/list
+type ListEscalationsParams struct {
+	PageSize int
+	After    string
+
+	EscalationPathOneOf []string
+	EscalationPathNotIn []string
+	StatusOneOf         []string
+	StatusNotIn         []string
+	AlertOneOf          []string
+	AlertNotIn          []string
+
+	CreatedAtGte       string
+	CreatedAtLte       string
+	CreatedAtDateRange string
+	UpdatedAtGte       string
+	UpdatedAtLte       string
+	UpdatedAtDateRange string
+
+	IdempotencyKeyIs         string
+	IdempotencyKeyStartsWith string
+}
+
+// ListEscalationsResponse is the API response for listing escalations.
+type ListEscalationsResponse struct {
+	Escalations    []json.RawMessage `json:"escalations"`
+	PaginationMeta struct {
+		After            string `json:"after,omitempty"`
+		PageSize         int    `json:"page_size"`
+		TotalRecordCount int    `json:"total_record_count,omitempty"`
+	} `json:"pagination_meta"`
+}
+
+// ListEscalations lists escalations with optional filters.
+func (c *Client) ListEscalations(params *ListEscalationsParams) (*ListEscalationsResponse, error) {
+	pageSize := 25
+	if params != nil && params.PageSize > 0 {
+		pageSize = params.PageSize
+	}
+	if pageSize > 50 {
+		pageSize = 50
+	}
+
+	v := url.Values{}
+	v.Set("page_size", strconv.Itoa(pageSize))
+	if params != nil {
+		if params.After != "" {
+			v.Set("after", params.After)
+		}
+		for _, id := range params.EscalationPathOneOf {
+			v.Add("escalation_path[one_of]", id)
+		}
+		for _, id := range params.EscalationPathNotIn {
+			v.Add("escalation_path[not_in]", id)
+		}
+		for _, s := range params.StatusOneOf {
+			v.Add("status[one_of]", s)
+		}
+		for _, s := range params.StatusNotIn {
+			v.Add("status[not_in]", s)
+		}
+		for _, id := range params.AlertOneOf {
+			v.Add("alert[one_of]", id)
+		}
+		for _, id := range params.AlertNotIn {
+			v.Add("alert[not_in]", id)
+		}
+		if params.CreatedAtGte != "" {
+			v.Set("created_at[gte]", params.CreatedAtGte)
+		}
+		if params.CreatedAtLte != "" {
+			v.Set("created_at[lte]", params.CreatedAtLte)
+		}
+		if params.CreatedAtDateRange != "" {
+			v.Set("created_at[date_range]", params.CreatedAtDateRange)
+		}
+		if params.UpdatedAtGte != "" {
+			v.Set("updated_at[gte]", params.UpdatedAtGte)
+		}
+		if params.UpdatedAtLte != "" {
+			v.Set("updated_at[lte]", params.UpdatedAtLte)
+		}
+		if params.UpdatedAtDateRange != "" {
+			v.Set("updated_at[date_range]", params.UpdatedAtDateRange)
+		}
+		if params.IdempotencyKeyIs != "" {
+			v.Set("idempotency_key[is]", params.IdempotencyKeyIs)
+		}
+		if params.IdempotencyKeyStartsWith != "" {
+			v.Set("idempotency_key[starts_with]", params.IdempotencyKeyStartsWith)
+		}
+	}
+
+	endpoint := "/escalations?" + v.Encode()
+	respBody, err := c.doRequest("GET", endpoint, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out ListEscalationsResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal escalations list: %w", err)
+	}
+	return &out, nil
+}
+
+// GetEscalation returns one escalation by ID.
+func (c *Client) GetEscalation(id string) (json.RawMessage, error) {
+	if id == "" {
+		return nil, fmt.Errorf("escalation id is required")
+	}
+	respBody, err := c.doRequest("GET", fmt.Sprintf("/escalations/%s", id), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		Escalation json.RawMessage `json:"escalation"`
+	}
+	if err := json.Unmarshal(respBody, &wrap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal escalation: %w", err)
+	}
+	return wrap.Escalation, nil
+}
+
+// CreateEscalationRequest is the body for POST /escalations.
+// Provide either EscalationPathID or UserIDs, not both.
+type CreateEscalationRequest struct {
+	Title            string   `json:"title"`
+	Description      string   `json:"description,omitempty"`
+	EscalationPathID string   `json:"escalation_path_id,omitempty"`
+	UserIDs          []string `json:"user_ids,omitempty"`
+	IdempotencyKey   string   `json:"idempotency_key,omitempty"`
+}
+
+// CreateEscalation triggers a new escalation.
+func (c *Client) CreateEscalation(req *CreateEscalationRequest) (json.RawMessage, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+	respBody, err := c.doRequest("POST", "/escalations", nil, req)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		Escalation json.RawMessage `json:"escalation"`
+	}
+	if err := json.Unmarshal(respBody, &wrap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal create escalation response: %w", err)
+	}
+	return wrap.Escalation, nil
+}

--- a/internal/client/escalations_test.go
+++ b/internal/client/escalations_test.go
@@ -1,0 +1,121 @@
+package client
+
+import (
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestListEscalationPaths(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			assertEqual(t, "GET", req.Method)
+			assertEqual(t, "25", req.URL.Query().Get("page_size"))
+			assertEqual(t, "after_cursor", req.URL.Query().Get("after"))
+			body := `{"escalation_paths":[{"id":"p1","name":"Path"}],"pagination_meta":{"after":"next","page_size":25}}`
+			return mockResponse(http.StatusOK, body), nil
+		},
+	}
+	c := NewTestClient(mockClient)
+	res, err := c.ListEscalationPaths(&ListEscalationPathsParams{PageSize: 25, After: "after_cursor"})
+	assertNoError(t, err)
+	if len(res.EscalationPaths) != 1 {
+		t.Fatalf("paths: got %d", len(res.EscalationPaths))
+	}
+	if res.PaginationMeta.After != "next" {
+		t.Errorf("after: %q", res.PaginationMeta.After)
+	}
+}
+
+func TestListEscalationPaths_CapsPageSize(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.URL.Query().Get("page_size") != "25" {
+				t.Errorf("expected cap 25, got %q", req.URL.Query().Get("page_size"))
+			}
+			return mockResponse(http.StatusOK, `{"escalation_paths":[],"pagination_meta":{"page_size":25}}`), nil
+		},
+	}
+	c := NewTestClient(mockClient)
+	_, err := c.ListEscalationPaths(&ListEscalationPathsParams{PageSize: 100})
+	assertNoError(t, err)
+}
+
+func TestDestroyEscalationPath(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			assertEqual(t, "DELETE", req.Method)
+			if req.URL.Path != "/escalation_paths/ep_1" {
+				t.Errorf("path %s", req.URL.Path)
+			}
+			if req.Body != nil {
+				b, _ := io.ReadAll(req.Body)
+				if len(b) != 0 {
+					t.Errorf("unexpected body")
+				}
+			}
+			return mockResponse(http.StatusNoContent, ""), nil
+		},
+	}
+	c := NewTestClient(mockClient)
+	err := c.DestroyEscalationPath("ep_1")
+	assertNoError(t, err)
+}
+
+func TestListEscalations_Query(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			q := req.URL.Query()
+			assertEqual(t, "10", q.Get("page_size"))
+			if q.Get("status[one_of]") != "triggered" {
+				t.Errorf("status filter: %v", q["status[one_of]"])
+			}
+			body := `{"escalations":[],"pagination_meta":{"page_size":10}}`
+			return mockResponse(http.StatusOK, body), nil
+		},
+	}
+	c := NewTestClient(mockClient)
+	_, err := c.ListEscalations(&ListEscalationsParams{
+		PageSize:    10,
+		StatusOneOf: []string{"triggered"},
+	})
+	assertNoError(t, err)
+}
+
+func TestUpdateEscalationPath_PUT(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			assertEqual(t, "PUT", req.Method)
+			body := `{"escalation_path":{"id":"ep_1","name":"N"}}`
+			return mockResponse(http.StatusOK, body), nil
+		},
+	}
+	c := NewTestClient(mockClient)
+	raw, err := c.UpdateEscalationPath("ep_1", map[string]interface{}{"name": "N"})
+	assertNoError(t, err)
+	if string(raw) != `{"id":"ep_1","name":"N"}` {
+		t.Errorf("got %s", string(raw))
+	}
+}
+
+func TestCreateEscalation(t *testing.T) {
+	mockClient := &MockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			assertEqual(t, "POST", req.Method)
+			if req.URL.Path != "/escalations" {
+				t.Errorf("path %s", req.URL.Path)
+			}
+			body := `{"escalation":{"id":"e1","title":"T"}}`
+			return mockResponse(http.StatusCreated, body), nil
+		},
+	}
+	c := NewTestClient(mockClient)
+	raw, err := c.CreateEscalation(&CreateEscalationRequest{
+		Title:            "T",
+		EscalationPathID: "p1",
+	})
+	assertNoError(t, err)
+	if string(raw) != `{"id":"e1","title":"T"}` {
+		t.Errorf("got %s", string(raw))
+	}
+}

--- a/internal/handlers/escalations.go
+++ b/internal/handlers/escalations.go
@@ -1,0 +1,572 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/incident-io/incidentio-mcp-golang/internal/client"
+)
+
+// --- Escalation paths (Escalations V2) ---
+
+type ListEscalationPathsTool struct {
+	apiClient *client.Client
+}
+
+func NewListEscalationPathsTool(c *client.Client) *ListEscalationPathsTool {
+	return &ListEscalationPathsTool{apiClient: c}
+}
+
+func (t *ListEscalationPathsTool) Name() string { return "list_escalation_paths" }
+
+func (t *ListEscalationPathsTool) Description() string {
+	return "List escalation paths in your account (On-call). Pagination: use pagination_meta.after on the next call. " +
+		"See https://docs.incident.io/api-reference/escalations-v2/listpaths"
+}
+
+func (t *ListEscalationPathsTool) InputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"page_size": map[string]interface{}{
+				"type":        "integer",
+				"description": "Page size (1–25; API maximum 25)",
+				"minimum":     1,
+				"maximum":     25,
+			},
+			"after": map[string]interface{}{
+				"type":        "string",
+				"description": "Pagination cursor from pagination_meta.after",
+			},
+		},
+		"additionalProperties": false,
+	}
+}
+
+func (t *ListEscalationPathsTool) Execute(args map[string]interface{}) (string, error) {
+	params := &client.ListEscalationPathsParams{}
+	if pageSize, ok := args["page_size"].(float64); ok {
+		params.PageSize = int(pageSize)
+	}
+	if after, ok := args["after"].(string); ok {
+		params.After = after
+	}
+	result, err := t.apiClient.ListEscalationPaths(params)
+	if err != nil {
+		return "", fmt.Errorf("failed to list escalation paths: %w", err)
+	}
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}
+
+type GetEscalationPathTool struct {
+	apiClient *client.Client
+}
+
+func NewGetEscalationPathTool(c *client.Client) *GetEscalationPathTool {
+	return &GetEscalationPathTool{apiClient: c}
+}
+
+func (t *GetEscalationPathTool) Name() string { return "get_escalation_path" }
+
+func (t *GetEscalationPathTool) Description() string {
+	return "Get a single escalation path by ID. See https://docs.incident.io/api-reference/escalations-v2/showpath"
+}
+
+func (t *GetEscalationPathTool) InputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"id": map[string]interface{}{
+				"type":        "string",
+				"description": "Escalation path ID",
+				"minLength":   1,
+			},
+		},
+		"required":             []string{"id"},
+		"additionalProperties": false,
+	}
+}
+
+func (t *GetEscalationPathTool) Execute(args map[string]interface{}) (string, error) {
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("id is required")
+	}
+	raw, err := t.apiClient.GetEscalationPath(id)
+	if err != nil {
+		return "", fmt.Errorf("failed to get escalation path: %w", err)
+	}
+	var pretty interface{}
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		return "", fmt.Errorf("failed to decode escalation path: %w", err)
+	}
+	out, err := json.MarshalIndent(map[string]interface{}{"escalation_path": pretty}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}
+
+type CreateEscalationPathTool struct {
+	apiClient *client.Client
+}
+
+func NewCreateEscalationPathTool(c *client.Client) *CreateEscalationPathTool {
+	return &CreateEscalationPathTool{apiClient: c}
+}
+
+func (t *CreateEscalationPathTool) Name() string { return "create_escalation_path" }
+
+func (t *CreateEscalationPathTool) Description() string {
+	return "Create an escalation path. `payload` must match the API (name, path, team_ids, repeat_config, working_hours, …). " +
+		"Prefer building paths in the incident.io UI for complex graphs. " +
+		"See https://docs.incident.io/api-reference/escalations-v2/createpath"
+}
+
+func (t *CreateEscalationPathTool) InputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"payload": map[string]interface{}{
+				"type":        "object",
+				"description": "Request body as defined by Escalations V2 CreatePath (name, path, team_ids, etc.)",
+			},
+		},
+		"required":             []string{"payload"},
+		"additionalProperties": false,
+	}
+}
+
+func (t *CreateEscalationPathTool) Execute(args map[string]interface{}) (string, error) {
+	payload, ok := args["payload"].(map[string]interface{})
+	if !ok || payload == nil {
+		return "", fmt.Errorf("payload must be an object")
+	}
+	raw, err := t.apiClient.CreateEscalationPath(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to create escalation path: %w", err)
+	}
+	var pretty interface{}
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		return "", fmt.Errorf("failed to decode escalation path: %w", err)
+	}
+	out, err := json.MarshalIndent(map[string]interface{}{"escalation_path": pretty}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}
+
+type UpdateEscalationPathTool struct {
+	apiClient *client.Client
+}
+
+func NewUpdateEscalationPathTool(c *client.Client) *UpdateEscalationPathTool {
+	return &UpdateEscalationPathTool{apiClient: c}
+}
+
+func (t *UpdateEscalationPathTool) Name() string { return "update_escalation_path" }
+
+func (t *UpdateEscalationPathTool) Description() string {
+	return "Replace an escalation path (HTTP PUT). `payload` is the full path document. " +
+		"See https://docs.incident.io/api-reference/escalations-v2/updatepath"
+}
+
+func (t *UpdateEscalationPathTool) InputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"id": map[string]interface{}{
+				"type":        "string",
+				"description": "Escalation path ID",
+				"minLength":   1,
+			},
+			"payload": map[string]interface{}{
+				"type":        "object",
+				"description": "Full Escalations V2 path payload (name, path, team_ids, repeat_config, working_hours, …)",
+			},
+		},
+		"required":             []string{"id", "payload"},
+		"additionalProperties": false,
+	}
+}
+
+func (t *UpdateEscalationPathTool) Execute(args map[string]interface{}) (string, error) {
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("id is required")
+	}
+	payload, ok := args["payload"].(map[string]interface{})
+	if !ok || payload == nil {
+		return "", fmt.Errorf("payload must be an object")
+	}
+	raw, err := t.apiClient.UpdateEscalationPath(id, payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to update escalation path: %w", err)
+	}
+	var pretty interface{}
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		return "", fmt.Errorf("failed to decode escalation path: %w", err)
+	}
+	out, err := json.MarshalIndent(map[string]interface{}{"escalation_path": pretty}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}
+
+type DestroyEscalationPathTool struct {
+	apiClient *client.Client
+}
+
+func NewDestroyEscalationPathTool(c *client.Client) *DestroyEscalationPathTool {
+	return &DestroyEscalationPathTool{apiClient: c}
+}
+
+func (t *DestroyEscalationPathTool) Name() string { return "destroy_escalation_path" }
+
+func (t *DestroyEscalationPathTool) Description() string {
+	return "Archive (delete) an escalation path. Returns success with no resource body (HTTP 204). " +
+		"See https://docs.incident.io/api-reference/escalations-v2/destroypath"
+}
+
+func (t *DestroyEscalationPathTool) InputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"id": map[string]interface{}{
+				"type":        "string",
+				"description": "Escalation path ID to archive",
+				"minLength":   1,
+			},
+		},
+		"required":             []string{"id"},
+		"additionalProperties": false,
+	}
+}
+
+func (t *DestroyEscalationPathTool) Execute(args map[string]interface{}) (string, error) {
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("id is required")
+	}
+	if err := t.apiClient.DestroyEscalationPath(id); err != nil {
+		return "", fmt.Errorf("failed to destroy escalation path: %w", err)
+	}
+	out, err := json.MarshalIndent(map[string]interface{}{
+		"archived": true,
+		"id":       id,
+	}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}
+
+// --- Escalations (instances) ---
+
+type ListEscalationsTool struct {
+	apiClient *client.Client
+}
+
+func NewListEscalationsTool(c *client.Client) *ListEscalationsTool {
+	return &ListEscalationsTool{apiClient: c}
+}
+
+func (t *ListEscalationsTool) Name() string { return "list_escalations" }
+
+func (t *ListEscalationsTool) Description() string {
+	return "List escalations with optional filters (status, escalation path, alert, dates, idempotency key). " +
+		"Status values: pending, triggered, acked, resolved, expired, cancelled. " +
+		"See https://docs.incident.io/api-reference/escalations-v2/list"
+}
+
+func (t *ListEscalationsTool) InputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"page_size": map[string]interface{}{
+				"type":        "integer",
+				"description": "Page size (1–50; API maximum 50)",
+				"minimum":     1,
+				"maximum":     50,
+			},
+			"after": map[string]interface{}{
+				"type":        "string",
+				"description": "Pagination cursor from pagination_meta.after",
+			},
+			"escalation_path_one_of": map[string]interface{}{
+				"type":        "array",
+				"description": "Escalation path IDs (escalation_path[one_of])",
+				"items":       map[string]interface{}{"type": "string"},
+			},
+			"escalation_path_not_in": map[string]interface{}{
+				"type":        "array",
+				"description": "Escalation path IDs to exclude (escalation_path[not_in])",
+				"items":       map[string]interface{}{"type": "string"},
+			},
+			"status_one_of": map[string]interface{}{
+				"type":        "array",
+				"description": "Statuses to include (status[one_of])",
+				"items":       map[string]interface{}{"type": "string"},
+			},
+			"status_not_in": map[string]interface{}{
+				"type":        "array",
+				"description": "Statuses to exclude (status[not_in])",
+				"items":       map[string]interface{}{"type": "string"},
+			},
+			"alert_one_of": map[string]interface{}{
+				"type":        "array",
+				"description": "Alert IDs (alert[one_of])",
+				"items":       map[string]interface{}{"type": "string"},
+			},
+			"alert_not_in": map[string]interface{}{
+				"type":        "array",
+				"description": "Alert IDs to exclude (alert[not_in])",
+				"items":       map[string]interface{}{"type": "string"},
+			},
+			"created_at_gte": map[string]interface{}{
+				"type":        "string",
+				"description": "created_at[gte] (e.g. 2025-01-01)",
+			},
+			"created_at_lte": map[string]interface{}{
+				"type":        "string",
+				"description": "created_at[lte]",
+			},
+			"created_at_date_range": map[string]interface{}{
+				"type":        "string",
+				"description": "created_at[date_range] as start~end (e.g. 2025-01-01~2025-01-31)",
+			},
+			"updated_at_gte": map[string]interface{}{
+				"type":        "string",
+				"description": "updated_at[gte]",
+			},
+			"updated_at_lte": map[string]interface{}{
+				"type":        "string",
+				"description": "updated_at[lte]",
+			},
+			"updated_at_date_range": map[string]interface{}{
+				"type":        "string",
+				"description": "updated_at[date_range] as start~end",
+			},
+			"idempotency_key_is": map[string]interface{}{
+				"type":        "string",
+				"description": "idempotency_key[is] exact match",
+			},
+			"idempotency_key_starts_with": map[string]interface{}{
+				"type":        "string",
+				"description": "idempotency_key[starts_with] prefix",
+			},
+		},
+		"additionalProperties": false,
+	}
+}
+
+func stringSliceArg(args map[string]interface{}, key string) []string {
+	raw, ok := args[key].([]interface{})
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, v := range raw {
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func (t *ListEscalationsTool) Execute(args map[string]interface{}) (string, error) {
+	params := &client.ListEscalationsParams{}
+	if pageSize, ok := args["page_size"].(float64); ok {
+		params.PageSize = int(pageSize)
+	}
+	if after, ok := args["after"].(string); ok {
+		params.After = after
+	}
+	params.EscalationPathOneOf = stringSliceArg(args, "escalation_path_one_of")
+	params.EscalationPathNotIn = stringSliceArg(args, "escalation_path_not_in")
+	params.StatusOneOf = stringSliceArg(args, "status_one_of")
+	params.StatusNotIn = stringSliceArg(args, "status_not_in")
+	params.AlertOneOf = stringSliceArg(args, "alert_one_of")
+	params.AlertNotIn = stringSliceArg(args, "alert_not_in")
+	if s, ok := args["created_at_gte"].(string); ok {
+		params.CreatedAtGte = s
+	}
+	if s, ok := args["created_at_lte"].(string); ok {
+		params.CreatedAtLte = s
+	}
+	if s, ok := args["created_at_date_range"].(string); ok {
+		params.CreatedAtDateRange = s
+	}
+	if s, ok := args["updated_at_gte"].(string); ok {
+		params.UpdatedAtGte = s
+	}
+	if s, ok := args["updated_at_lte"].(string); ok {
+		params.UpdatedAtLte = s
+	}
+	if s, ok := args["updated_at_date_range"].(string); ok {
+		params.UpdatedAtDateRange = s
+	}
+	if s, ok := args["idempotency_key_is"].(string); ok {
+		params.IdempotencyKeyIs = s
+	}
+	if s, ok := args["idempotency_key_starts_with"].(string); ok {
+		params.IdempotencyKeyStartsWith = s
+	}
+
+	result, err := t.apiClient.ListEscalations(params)
+	if err != nil {
+		return "", fmt.Errorf("failed to list escalations: %w", err)
+	}
+	out, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}
+
+type GetEscalationTool struct {
+	apiClient *client.Client
+}
+
+func NewGetEscalationTool(c *client.Client) *GetEscalationTool {
+	return &GetEscalationTool{apiClient: c}
+}
+
+func (t *GetEscalationTool) Name() string { return "get_escalation" }
+
+func (t *GetEscalationTool) Description() string {
+	return "Get one escalation by ID. See https://docs.incident.io/api-reference/escalations-v2/show"
+}
+
+func (t *GetEscalationTool) InputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"id": map[string]interface{}{
+				"type":        "string",
+				"description": "Escalation ID",
+				"minLength":   1,
+			},
+		},
+		"required":             []string{"id"},
+		"additionalProperties": false,
+	}
+}
+
+func (t *GetEscalationTool) Execute(args map[string]interface{}) (string, error) {
+	id, ok := args["id"].(string)
+	if !ok || id == "" {
+		return "", fmt.Errorf("id is required")
+	}
+	raw, err := t.apiClient.GetEscalation(id)
+	if err != nil {
+		return "", fmt.Errorf("failed to get escalation: %w", err)
+	}
+	var pretty interface{}
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		return "", fmt.Errorf("failed to decode escalation: %w", err)
+	}
+	out, err := json.MarshalIndent(map[string]interface{}{"escalation": pretty}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}
+
+type CreateEscalationTool struct {
+	apiClient *client.Client
+}
+
+func NewCreateEscalationTool(c *client.Client) *CreateEscalationTool {
+	return &CreateEscalationTool{apiClient: c}
+}
+
+func (t *CreateEscalationTool) Name() string { return "create_escalation" }
+
+func (t *CreateEscalationTool) Description() string {
+	return "Create an escalation: page via escalation_path_id OR user_ids (mutually exclusive). " +
+		"Optional description, idempotency_key. Rate-limited (interactive use). " +
+		"See https://docs.incident.io/api-reference/escalations-v2/create"
+}
+
+func (t *CreateEscalationTool) InputSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"title": map[string]interface{}{
+				"type":        "string",
+				"description": "Escalation title",
+				"minLength":   1,
+			},
+			"description": map[string]interface{}{
+				"type":        "string",
+				"description": "Additional details",
+			},
+			"escalation_path_id": map[string]interface{}{
+				"type":        "string",
+				"description": "Follow this escalation path (do not set with user_ids)",
+			},
+			"user_ids": map[string]interface{}{
+				"type":        "array",
+				"description": "User IDs to page directly (do not set with escalation_path_id)",
+				"items":       map[string]interface{}{"type": "string"},
+			},
+			"idempotency_key": map[string]interface{}{
+				"type":        "string",
+				"description": "Dedupe key; same key returns existing escalation",
+			},
+		},
+		"required":             []string{"title"},
+		"additionalProperties": false,
+	}
+}
+
+func (t *CreateEscalationTool) Execute(args map[string]interface{}) (string, error) {
+	title, ok := args["title"].(string)
+	if !ok || title == "" {
+		return "", fmt.Errorf("title is required")
+	}
+	req := &client.CreateEscalationRequest{Title: title}
+	if d, ok := args["description"].(string); ok {
+		req.Description = d
+	}
+	if eid, ok := args["escalation_path_id"].(string); ok {
+		req.EscalationPathID = eid
+	}
+	if raw, ok := args["user_ids"].([]interface{}); ok {
+		for _, v := range raw {
+			if s, ok := v.(string); ok && s != "" {
+				req.UserIDs = append(req.UserIDs, s)
+			}
+		}
+	}
+	if k, ok := args["idempotency_key"].(string); ok {
+		req.IdempotencyKey = k
+	}
+
+	hasPath := req.EscalationPathID != ""
+	hasUsers := len(req.UserIDs) > 0
+	if hasPath == hasUsers {
+		return "", fmt.Errorf("set exactly one of escalation_path_id or user_ids (non-empty)")
+	}
+
+	raw, err := t.apiClient.CreateEscalation(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to create escalation: %w", err)
+	}
+	var pretty interface{}
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		return "", fmt.Errorf("failed to decode escalation: %w", err)
+	}
+	out, err := json.MarshalIndent(map[string]interface{}{"escalation": pretty}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return string(out), nil
+}

--- a/internal/handlers/registry.go
+++ b/internal/handlers/registry.go
@@ -87,6 +87,18 @@ func (r *ToolRegistry) RegisterAlertRouteTools(c *client.Client) {
 	r.RegisterTool("update_alert_route", NewUpdateAlertRouteTool(c))
 }
 
+// RegisterEscalationTools registers on-call escalation paths and escalations (incident.io Escalations V2 API).
+func (r *ToolRegistry) RegisterEscalationTools(c *client.Client) {
+	r.RegisterTool("list_escalation_paths", NewListEscalationPathsTool(c))
+	r.RegisterTool("get_escalation_path", NewGetEscalationPathTool(c))
+	r.RegisterTool("create_escalation_path", NewCreateEscalationPathTool(c))
+	r.RegisterTool("update_escalation_path", NewUpdateEscalationPathTool(c))
+	r.RegisterTool("destroy_escalation_path", NewDestroyEscalationPathTool(c))
+	r.RegisterTool("list_escalations", NewListEscalationsTool(c))
+	r.RegisterTool("get_escalation", NewGetEscalationTool(c))
+	r.RegisterTool("create_escalation", NewCreateEscalationTool(c))
+}
+
 // RegisterAlertSourceTools registers all alert source tools
 func (r *ToolRegistry) RegisterAlertSourceTools(c *client.Client) {
 	r.RegisterTool("list_alert_sources", NewListAlertSourcesTool(c))
@@ -135,6 +147,7 @@ func (r *ToolRegistry) RegisterAllTools(c *client.Client) {
 	r.RegisterRoleTools(c)
 	r.RegisterWorkflowTools(c)
 	r.RegisterAlertRouteTools(c)
+	r.RegisterEscalationTools(c)
 	r.RegisterAlertSourceTools(c)
 	r.RegisterCatalogTools(c)
 	r.RegisterCustomFieldTools(c)


### PR DESCRIPTION
Implement incident.io Escalations V2 endpoints: list/get/create/update/destroy escalation paths, plus list/get/create escalations. Wire new MCP tools via RegisterEscalationsV2Tools and add client tests.

Made-with: Cursor